### PR TITLE
Fix Setup Instructions for Service Account File in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ backend/token.json
 backend/service_account_key.json
 venv
 backend/Eduaid
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,7 +12,23 @@ EduAid is one such project currently available in the form of a browser extensio
 git clone https://github.com/AOSSIE-Org/EduAid.git
 cd EduAid
 ```
-## 2. Backend Setup
+
+### 2. Configure Google APIs
+
+#### Google Docs API
+
+1. Navigate to the `backend` folder.
+2. Open the `service_account_key.json` file.
+3. Enter the service account details for the Google Docs API.
+4. Refer to the [Google Docs API documentation](https://developers.google.com/docs/api/reference/rest) for more details.
+
+#### Google Forms API
+
+1. Open the `credentials.json` file in the `backend` folder.
+2. Enter the necessary credentials for the Google Forms API.
+3. Refer to the [Google Forms API quickstart guide](https://developers.google.com/forms/api/quickstart/python#set_up_your_environment) for setup instructions.
+
+## 3. Backend Setup
 
 You can choose to set up the backend manually or use an automated shell script.
 
@@ -48,22 +64,6 @@ You can choose to set up the backend manually or use an automated shell script.
 - If the script fails to run, ensure that you have execution permissions:
   ```bash
   chmod +x script.sh
-
-
-### 3. Configure Google APIs
-
-#### Google Docs API
-
-1. Navigate to the `backend` folder.
-2. Open the `service_account_key.json` file.
-3. Enter the service account details for the Google Docs API.
-4. Refer to the [Google Docs API documentation](https://developers.google.com/docs/api/reference/rest) for more details.
-
-#### Google Forms API
-
-1. Open the `credentials.json` file in the `backend` folder.
-2. Enter the necessary credentials for the Google Forms API.
-3. Refer to the [Google Forms API quickstart guide](https://developers.google.com/forms/api/quickstart/python#set_up_your_environment) for setup instructions.
 
 ### 4. Extension Setup
 


### PR DESCRIPTION
This pull request addresses an issue where users were unable to correctly set up the service account file before starting the server. The instructions for configuring the service account file were originally placed later in the documentation, leading to confusion and potential errors during the setup process.

Issue Resolved:
Issue: Users encountered difficulties setting up the service account file because the required steps were only mentioned after the server startup instructions.
Fix: I have updated the documentation to move the service account file setup instructions to appear before the server startup steps, ensuring a smoother setup experience.
Changes Made:
Moved the service account setup instructions to the appropriate position in the documentation, before the server start section.
Added clarity to the instructions to ensure users understand the importance of configuring the service account file beforehand.
Testing and Verification:
Verified that the new sequence of instructions eliminates confusion and allows users to complete the setup without issues.
Tested the updated process by following the steps to confirm the service starts correctly after configuring the service account.
Impact:
This change improves the usability of the documentation and prevents setup errors, making it easier for new users to get started.