### PR TITLE
Added open popup

### DIFF
--- a/extension/public/background.js
+++ b/extension/public/background.js
@@ -26,13 +26,14 @@ chrome.runtime.onInstalled.addListener(() => {
         await chrome.tabs.sendMessage(tab.id, { 
           selectedText: info.selectionText 
         });
-  
-        // Open the popup
-        // Note: Chrome extensions can't programmatically open the popup,
-        // but we can show the user where to click
+
+        // Set popup
         chrome.action.setPopup({ 
-          popup: "src/popup/popup.html"
+          popup: "src/pages/home/home.html"
         });
+
+        // Open popup
+        chrome.action.openPopup();
         
         // Show a badge to indicate text was captured
         chrome.action.setBadgeText({ 


### PR DESCRIPTION
In policy installed extensions (like manually installed ones) you can actually open the popup on user action on chrome 118 or higher
this adds support for the same, and open the home.html directly in the popup view as shown in the video

https://github.com/user-attachments/assets/5eeb56c8-5859-40e6-b4e5-4e5c288b2b02


references
[mdn](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/action/openPopup)
[chromedev ](https://developer.chrome.com/docs/extensions/reference/api/action#method-openPopup)