### PR TITLE
Fixed nested git repositories when running setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ backend/token.json
 backend/service_account_key.json
 venv
 backend/Eduaid
+s2v_reddit_2015_md.tar.gz

--- a/backend/script.sh
+++ b/backend/script.sh
@@ -12,17 +12,23 @@ fi
 source venv/bin/activate
 
 if [ ! -d "$REPO_DIR" ]; then
+
   git clone $REPO_URL
+  rm -rf "$REPO_DIR/.git"
 fi
 
 if [ ! -f "$S2V_ARCHIVE" ]; then
   wget $S2V_URL -O $S2V_ARCHIVE
+else
+  echo "Sense2Vec archive already exists, skipping download."
 fi
 
 if [ ! -d "$REPO_DIR/$S2V_DIR" ]; then
+  echo "Extracting Sense2Vec model..."
   mkdir -p $REPO_DIR/$S2V_DIR
   tar -xzvf $S2V_ARCHIVE -C $REPO_DIR/$S2V_DIR --strip-components=1
+else
+  echo "Sense2Vec model already extracted."
 fi
 
-# Deactivate virtual environment after completion
-source deactivate
+deactivate


### PR DESCRIPTION
## **Issue**
The current script clones a repository  inside the main project directory (`EduAid`), which introduces a **nested `.git` folder**.  
This leads to the following problems:  
1. Running `git status` shows unexpected changes from the nested repository.  
2. Executing `git add .` causes conflicts due to the presence of multiple `.git` folders.  
3. It complicates version control within the main project.

---
### Fixes Issue : #77 

## **Solution**
To resolve the issue, the script has been updated to **remove the `.git` directory** from the cloned repository immediately after cloning.  

### **Changes Made**
- Added a command to delete the `.git` folder within the cloned repository:
   ```bash
   rm -rf $REPO_DIR/.git
