### PR TITLE
Quantization done for the given Models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ backend/token.json
 backend/service_account_key.json
 venv
 backend/Eduaid
+._s2v_old
+s2v_reddit_2015_md.tar.gz
+

--- a/backend/Generator/main.py
+++ b/backend/Generator/main.py
@@ -61,7 +61,7 @@ def bnb_config_generator(quantization_type):
     elif quantization_type=="8bit":
         bnb_config = transformers.BitsAndBytesConfig(
             load_in_8bit=True,                  
-            #bnb_8bit_compute_dtype=torch.float16  
+            
         )
     
 
@@ -162,10 +162,10 @@ class ShortQGenerator:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
             self.device=torch.device(f"cuda:{gpu_id}")
-        # self.model.to(self.device)
+
         if quantization_type!="8bit":
             model_loading(self.model,self.device)
-        #model_loading(self.model,self.device)
+
         self.nlp = spacy.load('en_core_web_sm')
         self.s2v = Sense2Vec().from_disk('s2v_old')
         self.fdist = FreqDist(brown.words())
@@ -229,10 +229,10 @@ class ParaphraseGenerator:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
             self.device=torch.device(f"cuda:{gpu_id}")
-        # self.model.to(self.device)
+
         if quantization_type!="8bit":
             model_loading(self.model,self.device)
-        #model_loading(self.model,self.device)
+
         self.set_seed(42)
         
     def set_seed(self, seed):
@@ -302,12 +302,10 @@ class BoolQGenerator:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
             self.device=torch.device(f"cuda:{gpu_id}")
-        # self.model = T5ForConditionalGeneration.from_pretrained('Roasters/Boolean-Questions',quantization_config=self.bnb_config)
-        # self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        # self.model.to(self.device)
+       
         if quantization_type!="8bit":
             model_loading(self.model,self.device)
-        #model_loading(self.model,self.device)
+        
         self.set_seed(42)
         
     def set_seed(self, seed):
@@ -369,12 +367,10 @@ class AnswerPredictor:
             self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         else:
             self.device=torch.device(f"cuda:{gpu_id}")
-        # self.model = T5ForConditionalGeneration.from_pretrained('Roasters/Answer-Predictor',quantization_config=self.bnb_config)
-        # self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-        # self.model.to(self.device)
+        
         if quantization_type!="8bit":
             model_loading(self.model,self.device)
-        #model_loading(self.model,self.device)
+        
         # Load the lightweight NLI model for boolean question answering
         self.nli_model_name = "typeform/distilbert-base-uncased-mnli"
         self.nli_tokenizer = AutoTokenizer.from_pretrained(self.nli_model_name)

--- a/eduaid_web/package.json
+++ b/eduaid_web/package.json
@@ -11,7 +11,7 @@
     "react-dom": "^18.3.1",
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.26.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "react-switch": "^7.0.0",
     "web-vitals": "^2.1.4"
   },


### PR DESCRIPTION
This PR is with reference to the Issue #106

In this, Quantization of each model was required to provide support to devices with less GPU VRAM. The `backend/server.py` and `backend/Generator/main.py` are changed. 

Now the `backend/server.py` file take the following arguments 

`--quantization`: This represents whether the model are to be quantized or not. Additionally `auto` option is there, so that user doesnt have to set it manually.

`--gpu_id`: This represents the target CUDA GPU on which the models are to be run on. This is specifically helpful in multigpu systems where one can easily change on  which gpu the model has to run on. Additionally `auto` option automatically selects the target GPU

'--quantization_type': This represents what type of quantization the user wants to apply on the target  models. There are 2 different types of quantization `4bit` and `8bit`. The GPU usage differs for both these, with lowest with `4bit` quantization. The default is set to `4bit`.


Earlier without quantizations, the project wouldnt run on a consumer 3050 Ti Mobile GPU. Now with different quantizations, the model is loaded and inferenced upon on the same GPU.

The GPU load on inferencing with `4bit` quantization

![4bit](https://github.com/user-attachments/assets/cd5927d6-5b43-4271-aa40-03ed3f984493)

The GPU load on inferencing with `8bit` quantization

![8bit](https://github.com/user-attachments/assets/37d57be0-02ef-4d70-9778-cdf4e882ab23)


These are done for same tasks. The difference in GPU memory is due to different quantization configs.