### PR TITLE
Fix: MCQ Generation Page Break and Missing Options

### DIFF
--- a/eduaid_web/package-lock.json
+++ b/eduaid_web/package-lock.json
@@ -16,7 +16,7 @@
         "react-dom": "^18.3.1",
         "react-icons": "^5.2.1",
         "react-router-dom": "^6.26.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "react-switch": "^7.0.0",
         "web-vitals": "^2.1.4"
       },

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -60,12 +60,8 @@ const Output = () => {
 
       if (questionType === "get_mcq") {
         qaPairsFromStorage["output"].forEach((qaPair) => {
-          const options = qaPair.answer
-            .filter((ans) => !ans.correct)
-            .map((ans) => ans.answer);
-          const correctAnswer = qaPair.answer.find(
-            (ans) => ans.correct
-          )?.answer;
+          const options = qaPair.options;
+          const correctAnswer = qaPair.answer;
 
           combinedQaPairs.push({
             question: qaPair.question,


### PR DESCRIPTION
This PR fixes the issue where the MCQ generation process caused the page to break (#109). It also ensures all generated MCQs display their options correctly.

Note: In order to generate this PR on a local GPU, make use of the changes introduced in PR #107.

Closes #109

Before Fix 
https://github.com/user-attachments/assets/329bab79-9f9e-4cb1-a1e2-aeda46ee0712

After Fix
[Screencast from 2025-01-07 11-59-44.webm](https://github.com/user-attachments/assets/17d1ee49-b00b-4345-be6f-b6a698d5b831)
