### PR TITLE
Fix: Remove white space issue on quiz dashboard #156

### DIFF
--- a/extension/src/pages/previous/Previous.jsx
+++ b/extension/src/pages/previous/Previous.jsx
@@ -29,7 +29,7 @@ const Previous = () => {
   };
 
   return (
-    <div className="popup w-screen h-screen bg-[#02000F] flex flex-col justify-center items-center">
+    <div className="popup min-h-screen bg-[#02000F] flex flex-col justify-center items-center">
       <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient">
         <div className="flex items-end gap-[2px]">
           <img src={logo} alt="logo" className="w-16 my-4 ml-4 block" />


### PR DESCRIPTION
### Problem
On the quiz dashboard, sliding down reveals a white space at the bottom of the page, which disrupts the UI.

### Solution
- Fixed the CSS to prevent the white space from appearing.
- Verified responsiveness and tested the changes on different screen sizes.

### Steps to Test
1. Navigate to the quiz dashboard.
2. Slide down to check if the white space issue has been resolved.

### Before
![eduaid(Before)](https://github.com/user-attachments/assets/833ccb68-689e-4f97-acc0-0f1722332ef7)

### After
![eduaid(After)](https://github.com/user-attachments/assets/a6d5a4c6-f980-46af-ad36-5b228dc63f1a)
