### PR TITLE
Added extraction of content from webpage

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -5,7 +5,8 @@ import nltk
 import subprocess
 import os
 import glob
-
+import requests
+from bs4 import BeautifulSoup
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.feature_extraction.text import TfidfVectorizer
 nltk.download("stopwords")
@@ -361,6 +362,38 @@ def generate_gform():
         "https://docs.google.com/forms/d/" + result["formId"] + "/edit"
     )
     return edit_url
+
+@app.route("/extract_content",methods=["POST"])
+def extract_content_from_html(url):
+    response = requests.get(url)
+    soup = BeautifulSoup(response.text, 'html.parser')
+    body_content = soup.find('body').get_text(separator="\n", strip=True)
+    return body_content
+
+def extract_content_from_json(url):
+    response = requests.get(url)
+    data = response.json()
+    content = ""
+    
+    if 'text' in data:
+        content = data['text']
+    elif 'content' in data:
+        content = data['content']
+    else:
+        content = json.dumps(data, indent=2) 
+    return content
+
+def extract_content(url):
+    try:
+        response = requests.get(url)
+        if 'html' in response.headers.get('Content-Type', ''):
+            return extract_content_from_html(url)
+        elif 'json' in response.headers.get('Content-Type', ''):
+            return extract_content_from_json(url)
+        else:
+            return "Unsupported content type. The URL doesn't return HTML or JSON."  
+    except requests.exceptions.RequestException as e:
+        return f"Error: {e}"
 
 
 @app.route("/get_shortq_hard", methods=["POST"])


### PR DESCRIPTION
Content Extraction Implementation:

API Route: /get_content
This route allows users to extract text content from a provided document URL.
When a user submits a URL (such as a link to a webpage), the system fetches the content from that URL.
The content extraction logic processes the page, stripping out irrelevant HTML elements and returning only the relevant text for further question generation.
The endpoint handles potential errors (e.g., invalid URL, inaccessible content) and returns appropriate feedback to the user, ensuring smooth interaction.