### PR TITLE
Fix windows script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ You can choose to set up the backend manually or use an automated shell script.
      ```
    - This script will automatically download and extract the Sense2Vec model, install Python dependencies, and start the Flask app.
 
+### 🪟 Windows Users
+If using Git Bash:
+- Replace `python3` with `python` if needed.
+- Use `source venv/Scripts/activate` instead of `source venv/bin/activate`.
+- If `wget` is not available, `curl -L -o` is used in script.
+
+
 ### Troubleshooting
 
 - If the script fails to run, ensure that you have execution permissions:

--- a/backend/script.sh
+++ b/backend/script.sh
@@ -6,11 +6,13 @@ REPO_DIR="EduAid"
 S2V_ARCHIVE="s2v_reddit_2015_md.tar.gz"
 S2V_DIR="s2v_old"
 
+echo "Running on $OSTYPE"
+
 if [ ! -d "venv" ]; then
   python3 -m venv venv || python -m venv venv
 fi
 
-if [[ "$OSTYPE" == "msys" ]]; then
+if [[ "$OSTYPE" == "msys"* || "$OSTYPE" == "cygwin"* || "$OSTYPE" == "win32" ]]; then
   source venv/Scripts/activate
 else
   source venv/bin/activate
@@ -28,6 +30,5 @@ if [ ! -d "$REPO_DIR/$S2V_DIR" ]; then
   mkdir -p $REPO_DIR/$S2V_DIR
   tar -xzvf $S2V_ARCHIVE -C $REPO_DIR/$S2V_DIR --strip-components=1
 fi
-
 
 deactivate

--- a/backend/script.sh
+++ b/backend/script.sh
@@ -7,16 +7,21 @@ S2V_ARCHIVE="s2v_reddit_2015_md.tar.gz"
 S2V_DIR="s2v_old"
 
 if [ ! -d "venv" ]; then
-  python3 -m venv venv
+  python3 -m venv venv || python -m venv venv
 fi
-source venv/bin/activate
+
+if [[ "$OSTYPE" == "msys" ]]; then
+  source venv/Scripts/activate
+else
+  source venv/bin/activate
+fi
 
 if [ ! -d "$REPO_DIR" ]; then
   git clone $REPO_URL
 fi
 
 if [ ! -f "$S2V_ARCHIVE" ]; then
-  wget $S2V_URL -O $S2V_ARCHIVE
+  curl -L $S2V_URL -o $S2V_ARCHIVE
 fi
 
 if [ ! -d "$REPO_DIR/$S2V_DIR" ]; then
@@ -24,5 +29,5 @@ if [ ! -d "$REPO_DIR/$S2V_DIR" ]; then
   tar -xzvf $S2V_ARCHIVE -C $REPO_DIR/$S2V_DIR --strip-components=1
 fi
 
-# Deactivate virtual environment after completion
-source deactivate
+
+deactivate


### PR DESCRIPTION
### Fixes #256 
Enhanced script.sh for Windows compatibility:
- Used `curl` in place of `wget`
- Added support for activating venv on Windows
- Replaced `source deactivate` with `deactivate`
- Added fallback for `python` if `python3` not available
