### PR TITLE
Feature: Add "Clear input" button for input textarea (with confirmation) #322

### DIFF
--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -3,7 +3,7 @@ import "../index.css";
 import logo_trans from "../assets/aossie_logo_transparent.png"
 import stars from "../assets/stars.png";
 import cloud from "../assets/cloud.png";
-import { FaClipboard } from "react-icons/fa";
+import { FaClipboard, FaTrash } from "react-icons/fa";
 import Switch from "react-switch";
 import { Link } from "react-router-dom";
 import apiClient from "../utils/apiClient";
@@ -17,6 +17,11 @@ const Text_Input = () => {
   const [fileContent, setFileContent] = useState("");
   const [docUrl, setDocUrl] = useState("");
   const [isToggleOn, setIsToggleOn] = useState(0);
+
+  const handleClearText = () => {
+    const ok = window.confirm("Clear input?");
+    if (ok) setText("");
+  };
 
   const toggleSwitch = () => {
     setIsToggleOn((isToggleOn + 1) % 2);
@@ -168,6 +173,14 @@ const Text_Input = () => {
         <div className="relative bg-[#83b6cc40] mx-4 sm:mx-8 rounded-2xl p-4 min-h-[160px] sm:min-h-[200px] mt-4">
           <button className="absolute top-0 left-0 p-2 text-white focus:outline-none">
             <FaClipboard className="h-[24px] w-[24px]" />
+          </button>
+          <button
+            type="button"
+            onClick={handleClearText}
+            className="absolute top-0 left-10 p-2 text-white focus:outline-none"
+            title="Clear input"
+          >
+            <FaTrash className="h-[22px] w-[22px]" />
           </button>
           <textarea
             className="absolute inset-0 p-8 pt-6 bg-[#83b6cc40] text-lg sm:text-xl rounded-2xl outline-none resize-none h-full overflow-y-auto text-white caret-white"

--- a/extension/src/pages/text_input/TextInput.jsx
+++ b/extension/src/pages/text_input/TextInput.jsx
@@ -5,7 +5,7 @@ import logo from "../../assets/aossie_logo.webp";
 import stars from "../../assets/stars.png";
 import cloud from "../../assets/cloud.png";
 import arrow from "../../assets/arrow.png";
-import { FaClipboard , FaWikipediaW  } from "react-icons/fa";
+import { FaClipboard, FaTrash, FaWikipediaW } from "react-icons/fa";
 
 function Second() {
   const [text, setText] = useState("");
@@ -16,6 +16,11 @@ function Second() {
   const [fileContent, setFileContent] = useState('');
   const [docUrl, setDocUrl] = useState('');
   const [isToggleOn, setIsToggleOn] = useState(0);
+
+  const handleClearText = () => {
+    const ok = window.confirm("Clear input?");
+    if (ok) setText("");
+  };
 
   useEffect(() => {
     chrome.storage.local.get(["selectedText"], (result) => {
@@ -214,6 +219,14 @@ function Second() {
         <div className="relative bg-[#83b6cc40] mx-3 rounded-xl p-2 h-28">
           <button className="absolute top-0 left-0 p-2 text-white focus:outline-none">
             <FaClipboard className="h-[20px] w-[20px]" />
+          </button>
+          <button
+            type="button"
+            onClick={handleClearText}
+            className="absolute top-0 left-8 p-2 text-white focus:outline-none"
+            title="Clear input"
+          >
+            <FaTrash className="h-[18px] w-[18px]" />
           </button>
           <textarea
             className="absolute inset-0 p-8 pt-2 bg-[#83b6cc40] text-lg rounded-xl outline-none resize-none h-full overflow-y-auto text-white caret-white"


### PR DESCRIPTION
## Summary ( Issue #322 )
Adds a "Clear" button next to the existing Paste button to reset the input textarea, with a confirmation step to prevent accidental clears.

## Changes
- Added Clear button in the web input component.
- Added Clear button in the extension input component.
- Clear action confirms before setting textarea to empty.

## Acceptance Criteria Coverage
- [x] Clear empties the textarea
- [x] Confirmation step included
- [x] Word count still updates correctly
- [x] Implemented in both web and extension

## Files Changed
- eduaid_web/src/pages/Text_Input.jsx
- extension/src/pages/text_input/TextInput.jsx

## Team Name - EtherX
- Ritigya Gupta
- Sirjan Singh
- Heeral Mandolia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Clear Input button to remove text from the input field. The action includes a confirmation prompt to prevent accidental deletion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->