### PR TITLE
fix: Correct PyTorch device type checking for CUDA memory cleanup

### DIFF
--- a/backend/Generator/main.py
+++ b/backend/Generator/main.py
@@ -282,6 +282,9 @@ class AnswerPredictor:
             Question = self.tokenizer.decode(greedy_output[0], skip_special_tokens=True, clean_up_tokenization_spaces=True)
             answers.append(Question.strip().capitalize())
 
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
+
         return answers
 
     def predict_boolean_answer(self, payload):
@@ -303,6 +306,9 @@ class AnswerPredictor:
                 answers.append(True)
             else:
                 answers.append(False)
+
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
 
         return answers
 
@@ -444,6 +450,9 @@ class QuestionGenerator:
         else:
             print("Skipping evaluation step.\n")
             qa_list = self._get_all_qa_pairs(generated_questions, qg_answers)
+
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
 
         return qa_list
 
@@ -724,6 +733,9 @@ class QAEvaluator:
 
         for i in range(len(encoded_qa_pairs)):
             scores[i] = self._evaluate_qa(encoded_qa_pairs[i])
+
+        if self.device.type == 'cuda':
+            torch.cuda.empty_cache()
 
         return [
             k for k, v in sorted(scores.items(), key=lambda item: item[1], reverse=True)


### PR DESCRIPTION
## Summary
Fixes #327 
Fixes critical bug where GPU memory cleanup was never executed due to incorrect device type checking.

## Problem
The code used `if torch.device == 'cuda':` which compares a class to a string, always evaluating to False.

## Solution
Changed all 4 instances to `if self.device.type == 'cuda':` which properly checks the device instance.

## Files Changed
`backend/Generator/main.py`

## Impact
**Before:** GPU memory never cleaned, leading to potential OOM errors  
**After:** Proper memory cleanup on CUDA devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified GPU detection and memory-management behavior across question and answer generation components to make device handling more consistent.

* **Bug Fixes / Stability**
  * Improved GPU memory clearing logic to reduce out-of-memory issues and provide more reliable generation performance when using a GPU.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->