### PR TITLE
Fix unwanted vertical scrollbar on home layout

### DIFF
--- a/eduaid_web/src/pages/Home.jsx
+++ b/eduaid_web/src/pages/Home.jsx
@@ -42,7 +42,7 @@ const Home = () => {
 
   return (
     <div className="popup w-screen h-screen bg-[#02000F] flex justify-center items-center">
-      <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient overflow-auto px-4 py-6 sm:px-8 md:px-16">
+      <div className="w-full h-auto bg-cust bg-opacity-50 bg-custom-gradient overflow-auto px-4 py-6 sm:px-8 md:px-16">
         <div className="max-w-5xl mx-auto">
           <img src={logo_trans} alt="logo" className="w-24 my-4 sm:my-6" />
 


### PR DESCRIPTION
### Summary
This PR fixes a global UI issue where a vertical scrollbar appeared even when content did not overflow the viewport.

### Root Cause
The issue was caused by using `h-full` inside a `h-screen` container while applying vertical padding, which resulted in slight viewport overflow on certain environments (notably Windows 10 at 1366×768).

### Fix
Replaced `h-full` with `h-auto` on the home layout container so the layout sizes naturally and avoids unnecessary overflow.

### Result
- Pages fit the viewport correctly
- Scrollbars appear only when content actually overflows
- Layout behaves consistently across screen sizes and OS

Fixes #345 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed home page layout to properly resize based on content instead of maintaining a fixed full-screen height.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->