### PR TITLE
fix: resolve forEach error when generating all question types

### DIFF
--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -96,9 +96,10 @@ const Output = () => {
     if (qaPairsFromStorage) {
       const combinedQaPairs = [];
 
+      // Handle "get_problems" (all types) response - output_boolq
       if (qaPairsFromStorage["output_boolq"]) {
         qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
-          (question, index) => {
+          (question) => {
             combinedQaPairs.push({
               question,
               question_type: "Boolean",
@@ -108,6 +109,7 @@ const Output = () => {
         );
       }
 
+      // Handle "get_problems" (all types) response - output_mcq
       if (qaPairsFromStorage["output_mcq"]) {
         qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
           combinedQaPairs.push({
@@ -120,41 +122,54 @@ const Output = () => {
         });
       }
 
-      if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      // Handle "get_problems" (all types) response - output_shortq
+      if (qaPairsFromStorage["output_shortq"]) {
+        qaPairsFromStorage["output_shortq"]["questions"].forEach((qaPair) => {
           combinedQaPairs.push({
-            question: qaPair.question_statement,
-            question_type: "MCQ",
-            options: qaPair.options,
-            answer: qaPair.answer,
-            context: qaPair.context,
-          });
-        });
-      }
-
-      if (questionType == "get_boolq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question: qaPair,
-            question_type: "Boolean",
-          });
-        });
-      } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question:
-              qaPair.question || qaPair.question_statement || qaPair.Question,
-            options: qaPair.options,
-            answer: qaPair.answer || qaPair.Answer,
+            question: qaPair.Question,
+            answer: qaPair.Answer,
             context: qaPair.context,
             question_type: "Short",
           });
         });
       }
 
+      // Handle individual endpoint responses (only when "output" key exists)
+      if (qaPairsFromStorage["output"]) {
+        if (questionType === "get_mcq") {
+          qaPairsFromStorage["output"].forEach((qaPair) => {
+            combinedQaPairs.push({
+              question: qaPair.question_statement,
+              question_type: "MCQ",
+              options: qaPair.options,
+              answer: qaPair.answer,
+              context: qaPair.context,
+            });
+          });
+        } else if (questionType === "get_boolq") {
+          qaPairsFromStorage["output"].forEach((qaPair) => {
+            combinedQaPairs.push({
+              question: qaPair,
+              question_type: "Boolean",
+            });
+          });
+        } else if (questionType === "get_shortq") {
+          qaPairsFromStorage["output"].forEach((qaPair) => {
+            combinedQaPairs.push({
+              question:
+                qaPair.question || qaPair.question_statement || qaPair.Question,
+              options: qaPair.options,
+              answer: qaPair.answer || qaPair.Answer,
+              context: qaPair.context,
+              question_type: "Short",
+            });
+          });
+        }
+      }
+
       setQaPairs(combinedQaPairs);
     }
-  }, []);
+  }, [questionType]);
 
   const generateGoogleForm = async () => {
     try {


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where selecting "All Questions" option on the question type page causes a `TypeError: Cannot read properties of undefined (reading 'forEach')` error, preventing users from generating mixed question types.

### Problem

When users select "All Questions" (`get_problems` endpoint), the `Output.jsx` component fails to properly handle the response structure. The backend returns a different format for combined questions:

**Individual endpoints** return:
```json
{ "output": [...] }
```

**All questions endpoint** returns:
```json
{
  "output_mcq": { "questions": [...] },
  "output_boolq": { "Boolean_Questions": [...] },
  "output_shortq": { "questions": [...] }
}
```

The existing code had a flawed condition that checked for `output_mcq` OR `questionType === "get_mcq"`, then attempted to access `qaPairsFromStorage["output"]` which doesn't exist in the combined response.

### Solution

- Restructured the data processing logic to clearly separate handling of combined responses (`get_problems`) from individual endpoint responses
- Added missing handler for `output_shortq` from the combined response
- Wrapped individual endpoint handlers inside a check for the `output` key existence
- Added `questionType` to the useEffect dependency array for proper re-rendering

### Changes Made

| File | Description |
|------|-------------|
| `eduaid_web/src/pages/Output.jsx` | Fixed useEffect logic to properly handle both response formats |

### Testing Checklist

- [x] MCQ questions display correctly when selecting "MCQ" only
- [x] Boolean questions display correctly when selecting "Boolean" only
- [x] Short answer questions display correctly when selecting "Short Answer" only
- [x] All three question types display together when selecting "All Questions"
- [x] No console errors for any question type selection
- [x] PDF export functionality works
- [x] Google Form generation works

---

## Technical Details

### Root Cause Analysis

The bug was located in `eduaid_web/src/pages/Output.jsx` at lines 93-157. The issue stemmed from:

1. **Flawed conditional logic** (line 123): The condition `if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq")` evaluated to `true` when using `get_problems` (because `output_mcq` exists), but then tried to access `qaPairsFromStorage["output"]` which doesn't exist for combined responses.

2. **Missing handler**: There was no code to process `output_shortq` from the `get_problems` response.

3. **Duplicate processing**: Lines 111-121 already handled `output_mcq`, but lines 123-133 attempted to handle it again with incorrect logic.

### Code Changes

The fix restructures the useEffect to:

1. First handle all `get_problems` response keys (`output_boolq`, `output_mcq`, `output_shortq`)
2. Then handle individual endpoint responses only when the `output` key exists
3. Use strict equality checks (`===`) instead of loose equality (`==`)
4. Add `questionType` to the dependency array

---

## Issue Reference

**Fixes #221** - Bug: "forEach" error for "all type" questions due to missing "output" key in qaPairs

---

## Backward Compatibility

This fix is fully backward compatible:
- Individual question type selection continues to work as before
- No changes to backend API required
- No breaking changes to the UI/UX