### PR TITLE
Fix: Enforce consistent popup size using scoped CSS (Fixes #316)

### DIFF
--- a/extension/src/index.css
+++ b/extension/src/index.css
@@ -34,3 +34,21 @@
   -ms-overflow-style: none;  
   scrollbar-width: none;
 }
+
+/* --- FIX FOR ISSUE #316 (Popup Sizing) --- */
+/* These rules apply ONLY when <html class="is-popup"> is present */
+
+html.is-popup,
+html.is-popup body {
+  width: 420px;
+  height: 600px;
+  margin: 0;
+  padding: 0;
+  overflow: hidden; /* Prevent scrollbars on the window itself */
+}
+
+html.is-popup #root {
+  width: 100%;      /* Force root to fill the 420px container */
+  height: 100%;     /* Force root to fill the 600px container */
+  border-radius: 0; /* Reset the 50% radius so corners aren't cut off */
+}

--- a/extension/src/popup/popup.html
+++ b/extension/src/popup/popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="is-popup">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
**Fixes #316**

### **Description**
This PR fixes the inconsistent initial sizing of the extension popup by enforcing explicit dimensions (420px x 600px) only when the extension is opened as a popup.

### **The Problem**
* Previously, global styles were applied to `html` and `body` in `index.css` to fix the popup size.
* **The Bug:** These global styles polluted other pages in the extension (like the full-screen Home page), incorrectly forcing them to be small (420x600px) as well.

### **The Solution**
I have refactored the CSS to use **Scoped Styles**:
1.  **HTML Hook:** Added a specific class `is-popup` to `extension/src/popup/popup.html`.
2.  **Targeted CSS:** Updated `index.css` to apply the fixed dimensions **only** when the `html.is-popup` class is present.
3.  **Result:** The popup is perfectly sized (420x600px), while other pages (Home, History) remain fully responsive and unaffected.

### **Screenshots**
<img width="1918" height="1198" alt="image" src="https://github.com/user-attachments/assets/eeddb49e-9b99-4a50-bcc1-b59c997c5f1c" />

### **Type of Change**
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement

### **Verification**
- [x] Built the extension locally (`npm run build`).
- [x] Loaded unpacked extension in Chrome.
- [x] Verified popup opens at correct size (420x600) without scrollbars.
- [x] Verified that other pages (e.g., Home) are NOT affected by this change.

### **Checklist**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas