### PR TITLE
Fix invalid PyTorch version pin in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==2.5.1
+torch==2.2.2
 transformers==4.46.1
 sense2vec==2.0.2
 strsim==0.0.3


### PR DESCRIPTION
## Addressed Issues
Fixes #413

## Problem
The project pins PyTorch to a version that is not available on PyPI (`torch==2.5.1`), causing `pip install -r requirements.txt` to fail with:
```
ERROR: No matching distribution found for torch==2.5.1
```

This blocks fresh installations and prevents new contributors from setting up the project.

## Solution
Updated PyTorch version to `torch==2.2.2`, which is:
- Stable and available on PyPI
- Compatible with the existing codebase
- Works across macOS, Linux, and Windows

## Testing
- [x] Successfully installed dependencies with `pip install -r requirements.txt`
- [x] No version conflicts with other dependencies
- [x] Backend starts without errors

## Scope
- **Files changed**: `requirements.txt` only
- **Type**: Dependency version fix
- **Breaking changes**: None
- **Functional changes**: None (only fixes installation)

## Note
This PR addresses only the PyTorch version mismatch. The Sense2Vec model loading issue requires separate investigation and will be handled in a future PR.

## Checklist
- [x] My PR addresses a single issue
- [x] My code follows the project's conventions
- [x] No new warnings or errors
- [x] I have joined the Discord server
- [x] I have read the Contribution Guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python dependencies to ensure system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->