### PR TITLE
fix(boolean): unify backend payload to resolve missing answers in PDF export

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -74,8 +74,17 @@ def get_boolq():
     output = BoolQGen.generate_boolq(
         {"input_text": input_text, "max_questions": max_questions}
     )
-    boolean_questions = output["Boolean_Questions"]
-    return jsonify({"output": boolean_questions})
+    boolean_questions = output.get("Boolean_Questions", [])
+    raw_answers = answer.predict_boolean_answer(
+        {"input_text": input_text, "input_question": boolean_questions}
+    )
+    string_answers = ["True" if ans else "False" for ans in raw_answers]
+    return jsonify({
+        "output": boolean_questions,
+        "answers": string_answers,
+        "text": output.get("Text", ""),
+        "count": output.get("Count", max_questions)
+    })
 
 
 @app.route("/get_shortq", methods=["POST"])

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -7,9 +7,7 @@ import { FiShuffle, FiEdit2, FiCheck, FiX } from "react-icons/fi";
 
 const Output = () => {
   const [qaPairs, setQaPairs] = useState([]);
-  const [questionType, setQuestionType] = useState(
-    localStorage.getItem("selectedQuestionType")
-  );
+  const questionType = localStorage.getItem("selectedQuestionType");
   const [pdfMode, setPdfMode] = useState("questions");
   const [editingIndex, setEditingIndex] = useState(null);
   const [editedQuestion, setEditedQuestion] = useState("");
@@ -102,11 +100,11 @@ const Output = () => {
 
     if (Object.keys(qaPairsFromStorage).length > 0) {
       const combinedQaPairs = [];
-      const hasStructuredKeys = 
+      const hasStructuredKeys = Boolean(
         qaPairsFromStorage.output_boolq || 
         qaPairsFromStorage.output_mcq || 
-        qaPairsFromStorage.output_shortq;
-
+        qaPairsFromStorage.output_shortq
+      );
       if (qaPairsFromStorage.output_boolq) {
         const boolData = qaPairsFromStorage.output_boolq;
         const questions = boolData.Boolean_Questions || boolData.output;
@@ -162,10 +160,10 @@ const Output = () => {
         } else if (questionType === "get_mcq") {
           qaPairsFromStorage.output.forEach((qaPair) => {
             combinedQaPairs.push({
-              question: qaPair.question_statement,
+              question: qaPair.question || qaPair.question_statement || qaPair.Question,
               question_type: "MCQ",
               options: qaPair.options,
-              answer: qaPair.answer,
+              answer: qaPair.answer || qaPair.Answer || qaPair.correctAnswer,
               context: qaPair.context,
             });
           });

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -91,21 +91,27 @@ const Output = () => {
   };
 
   useEffect(() => {
-    const qaPairsFromStorage =
-      JSON.parse(localStorage.getItem("qaPairs")) || {};
+    const qaPairsFromStorage = JSON.parse(localStorage.getItem("qaPairs")) || {};
+    
     if (qaPairsFromStorage) {
       const combinedQaPairs = [];
 
       if (qaPairsFromStorage["output_boolq"]) {
-        qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
-          (question, index) => {
+        const boolData = qaPairsFromStorage["output_boolq"];
+        const questions = boolData["Boolean_Questions"] || boolData["output"];
+        const answers = boolData["answers"];
+        const context = boolData["Text"] || boolData["text"];
+
+        if (questions && Array.isArray(questions)) {
+          questions.forEach((question, index) => {
             combinedQaPairs.push({
               question,
               question_type: "Boolean",
-              context: qaPairsFromStorage["output_boolq"]["Text"],
+              context: context,
+              answer: answers && answers[index] ? answers[index] : "Answer not found",
             });
-          }
-        );
+          });
+        }
       }
 
       if (qaPairsFromStorage["output_mcq"]) {
@@ -132,18 +138,21 @@ const Output = () => {
         });
       }
 
-      if (questionType == "get_boolq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      if (questionType === "get_boolq" && qaPairsFromStorage["output"]) {
+        const answers = qaPairsFromStorage["answers"];
+        
+        qaPairsFromStorage["output"].forEach((qaPair, index) => {
           combinedQaPairs.push({
             question: qaPair,
             question_type: "Boolean",
+            answer: answers && answers[index] ? answers[index] : "Answer not found",
           });
         });
-      } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
+      } 
+      else if (qaPairsFromStorage["output"] && questionType !== "get_mcq" && questionType !== "get_boolq") {
         qaPairsFromStorage["output"].forEach((qaPair) => {
           combinedQaPairs.push({
-            question:
-              qaPair.question || qaPair.question_statement || qaPair.Question,
+            question: qaPair.question || qaPair.question_statement || qaPair.Question,
             options: qaPair.options,
             answer: qaPair.answer || qaPair.Answer,
             context: qaPair.context,
@@ -154,7 +163,7 @@ const Output = () => {
 
       setQaPairs(combinedQaPairs);
     }
-  }, []);
+  }, [questionType]);
 
   const generateGoogleForm = async () => {
     try {

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -91,10 +91,21 @@ const Output = () => {
   };
 
   useEffect(() => {
-    const qaPairsFromStorage = JSON.parse(localStorage.getItem("qaPairs")) || {};
+    let qaPairsFromStorage = {};
+    try {
+      qaPairsFromStorage = JSON.parse(localStorage.getItem("qaPairs")) || {};
+    } catch (e) {
+      console.error("Failed to parse qaPairs from localStorage:", e);
+      qaPairsFromStorage = {};
+    }
 
-    if (qaPairsFromStorage) {
+    if (Object.keys(qaPairsFromStorage).length > 0) {
       const combinedQaPairs = [];
+      const hasStructuredKeys = 
+        qaPairsFromStorage.output_boolq || 
+        qaPairsFromStorage.output_mcq || 
+        qaPairsFromStorage.output_shortq;
+
       if (qaPairsFromStorage.output_boolq) {
         const boolData = qaPairsFromStorage.output_boolq;
         const questions = boolData.Boolean_Questions || boolData.output;
@@ -136,14 +147,14 @@ const Output = () => {
         });
       }
 
-      
-      if (Array.isArray(qaPairsFromStorage.output)) {
+      if (!hasStructuredKeys && Array.isArray(qaPairsFromStorage.output)) {
         if (questionType === "get_boolq") {
           const answers = qaPairsFromStorage.answers;
           qaPairsFromStorage.output.forEach((qaPair, index) => {
             combinedQaPairs.push({
               question: qaPair,
               question_type: "Boolean",
+              context: qaPairsFromStorage.text || qaPairsFromStorage.Text,
               answer: answers?.[index] ?? "Answer not found",
             });
           });
@@ -172,7 +183,7 @@ const Output = () => {
 
       setQaPairs(combinedQaPairs);
     }
-  }, [questionType]);
+  }, []);
 
   const generateGoogleForm = async () => {
     try {

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -91,6 +91,7 @@ const Output = () => {
   };
 
   useEffect(() => {
+    const questionType = localStorage.getItem("selectedQuestionType");
     let qaPairsFromStorage = {};
     try {
       qaPairsFromStorage = JSON.parse(localStorage.getItem("qaPairs")) || {};

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -125,10 +125,10 @@ const Output = () => {
       if (qaPairsFromStorage.output_mcq && Array.isArray(qaPairsFromStorage.output_mcq.questions)) {
         qaPairsFromStorage.output_mcq.questions.forEach((qaPair) => {
           combinedQaPairs.push({
-            question: qaPair.question_statement,
+            question: qaPair.question ?? qaPair.question_statement ?? qaPair.Question,
             question_type: "MCQ",
             options: qaPair.options,
-            answer: qaPair.answer,
+            answer: qaPair.answer ?? qaPair.Answer,
             context: qaPair.context,
           });
         });
@@ -137,9 +137,9 @@ const Output = () => {
       if (qaPairsFromStorage.output_shortq && Array.isArray(qaPairsFromStorage.output_shortq.questions)) {
         qaPairsFromStorage.output_shortq.questions.forEach((qaPair) => {
           combinedQaPairs.push({
-            question: qaPair.question || qaPair.question_statement || qaPair.Question,
+            question: qaPair.question ?? qaPair.question_statement ?? qaPair.Question,
             options: qaPair.options,
-            answer: qaPair.answer || qaPair.Answer,
+            answer: qaPair.answer ?? qaPair.Answer,
             context: qaPair.context,
             question_type: "Short",
           });
@@ -170,9 +170,9 @@ const Output = () => {
         } else {
           qaPairsFromStorage.output.forEach((qaPair) => {
             combinedQaPairs.push({
-              question: qaPair.question || qaPair.question_statement || qaPair.Question,
+              question: qaPair.question ?? qaPair.question_statement ?? qaPair.Question,
               options: qaPair.options,
-              answer: qaPair.answer || qaPair.Answer,
+              answer: qaPair.answer ?? qaPair.Answer,
               context: qaPair.context,
               question_type: "Short",
             });

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -92,30 +92,28 @@ const Output = () => {
 
   useEffect(() => {
     const qaPairsFromStorage = JSON.parse(localStorage.getItem("qaPairs")) || {};
-    
+
     if (qaPairsFromStorage) {
       const combinedQaPairs = [];
+      if (qaPairsFromStorage.output_boolq) {
+        const boolData = qaPairsFromStorage.output_boolq;
+        const questions = boolData.Boolean_Questions || boolData.output;
+        const answers = boolData.answers;
 
-      if (qaPairsFromStorage["output_boolq"]) {
-        const boolData = qaPairsFromStorage["output_boolq"];
-        const questions = boolData["Boolean_Questions"] || boolData["output"];
-        const answers = boolData["answers"];
-        const context = boolData["Text"] || boolData["text"];
-
-        if (questions && Array.isArray(questions)) {
+        if (Array.isArray(questions)) {
           questions.forEach((question, index) => {
             combinedQaPairs.push({
               question,
               question_type: "Boolean",
-              context: context,
-              answer: answers && answers[index] ? answers[index] : "Answer not found",
+              context: boolData.Text || boolData.text,
+              answer: answers?.[index] ?? "Answer not found",
             });
           });
         }
       }
 
-      if (qaPairsFromStorage["output_mcq"]) {
-        qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
+      if (qaPairsFromStorage.output_mcq && Array.isArray(qaPairsFromStorage.output_mcq.questions)) {
+        qaPairsFromStorage.output_mcq.questions.forEach((qaPair) => {
           combinedQaPairs.push({
             question: qaPair.question_statement,
             question_type: "MCQ",
@@ -126,31 +124,8 @@ const Output = () => {
         });
       }
 
-      if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question: qaPair.question_statement,
-            question_type: "MCQ",
-            options: qaPair.options,
-            answer: qaPair.answer,
-            context: qaPair.context,
-          });
-        });
-      }
-
-      if (questionType === "get_boolq" && qaPairsFromStorage["output"]) {
-        const answers = qaPairsFromStorage["answers"];
-        
-        qaPairsFromStorage["output"].forEach((qaPair, index) => {
-          combinedQaPairs.push({
-            question: qaPair,
-            question_type: "Boolean",
-            answer: answers && answers[index] ? answers[index] : "Answer not found",
-          });
-        });
-      } 
-      else if (qaPairsFromStorage["output"] && questionType !== "get_mcq" && questionType !== "get_boolq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      if (qaPairsFromStorage.output_shortq && Array.isArray(qaPairsFromStorage.output_shortq.questions)) {
+        qaPairsFromStorage.output_shortq.questions.forEach((qaPair) => {
           combinedQaPairs.push({
             question: qaPair.question || qaPair.question_statement || qaPair.Question,
             options: qaPair.options,
@@ -159,6 +134,40 @@ const Output = () => {
             question_type: "Short",
           });
         });
+      }
+
+      
+      if (Array.isArray(qaPairsFromStorage.output)) {
+        if (questionType === "get_boolq") {
+          const answers = qaPairsFromStorage.answers;
+          qaPairsFromStorage.output.forEach((qaPair, index) => {
+            combinedQaPairs.push({
+              question: qaPair,
+              question_type: "Boolean",
+              answer: answers?.[index] ?? "Answer not found",
+            });
+          });
+        } else if (questionType === "get_mcq") {
+          qaPairsFromStorage.output.forEach((qaPair) => {
+            combinedQaPairs.push({
+              question: qaPair.question_statement,
+              question_type: "MCQ",
+              options: qaPair.options,
+              answer: qaPair.answer,
+              context: qaPair.context,
+            });
+          });
+        } else {
+          qaPairsFromStorage.output.forEach((qaPair) => {
+            combinedQaPairs.push({
+              question: qaPair.question || qaPair.question_statement || qaPair.Question,
+              options: qaPair.options,
+              answer: qaPair.answer || qaPair.Answer,
+              context: qaPair.context,
+              question_type: "Short",
+            });
+          });
+        }
       }
 
       setQaPairs(combinedQaPairs);


### PR DESCRIPTION
### PR Description

When generating Boolean questions on the web app, exporting them as a PDF results in `Answer X: undefined`. I noticed this happens because the web app never actually fetches the answers (the browser extension handles this via a separate API call to `/get_boolean_answer`, but `Output.jsx` didn't).

Instead of adding a messy secondary fetch to the React frontend and dealing with race conditions, I updated the backend to just return the answers alongside the questions in one go.

**What changed:**

* **Backend (`server.py`):** I updated the `/get_boolq` route so it passes the generated questions right into the existing `AnswerPredictor`. Now it returns a single payload with both the questions (`output`) and the answers (`answers`). I also cast the boolean values to strings (`"True"`/`"False"`) so React can render them safely.
* **Frontend (`Output.jsx`):** Tweaked the `useEffect` to grab the new `answers` array and map it to the questions by index. I also added a quick fallback (`"Answer not found"`) just in case.

### Addressed Issues:

Fixes #471

### Screenshots/Recordings:

**1. Backend: Postman check showing the new combined payload**

<img width="1361" height="806" alt="Screenshot 2026-02-25 173649" src="https://github.com/user-attachments/assets/b13ddff2-9cf2-4fdb-a90b-4548e8c58b3d" />


**2. Frontend: PDF export finally showing the answers**

<img width="989" height="834" alt="Screenshot 2026-02-25 173826" src="https://github.com/user-attachments/assets/17665fd6-d867-4882-8b6b-bd5b9899bfe5" />
<img width="800" height="902" alt="Screenshot 2026-02-25 173853" src="https://github.com/user-attachments/assets/dc6ef242-b403-4490-82b5-a7ad52143885" />


### Additional Notes:

**Backward Compatibility:** I made sure this backend change is strictly additive. By returning a separate `"answers"` array instead of changing the shape of the existing `"output"` array, the browser extension and Electron desktop app won't break. They'll just ignore the new data until someone updates their frontends to use it.

## Checklist

* [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
* [x] My code follows the project's code style and conventions
* [x] If applicable, I have made corresponding changes or additions to the documentation
* [x] If applicable, I have made corresponding changes or additions to tests
* [x] My changes generate no new warnings or errors
* [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
* [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
* [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure

Check one of the checkboxes below:

* [ ] This PR does not contain AI-generated code at all.
* [x] This PR contains AI-generated code. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Used LLMs (Gemini/ChatGPT) to bounce around architectural ideas and double check syntax. Wrote, integrated, and tested the actual implementation manually to ensure cross-platform compatibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boolean questions now include answers, full question text, context, and count metadata for richer display.

* **Bug Fixes**
  * More robust loading and parsing of stored QA data with graceful fallbacks.
  * Improved handling and validation of boolean, MCQ, and short-question formats to prevent malformed entries.
  * Fixed answer-question pairing and context preservation; UI updates correctly when question type changes.
* **Behavior**
  * Stored question type is now treated as a read-only value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->