### PR TITLE
Add Match-the-Columns Question Type

### DIFF
--- a/backend/Generator/match_columns.py
+++ b/backend/Generator/match_columns.py
@@ -1,0 +1,76 @@
+import spacy
+import random
+from nltk.tokenize import sent_tokenize
+
+nlp = spacy.load("en_core_web_sm")
+
+def extract_pairs_from_text(text, max_pairs=6):
+    doc = nlp(text)
+    pairs = []
+    seen_terms = set()
+    seen_definitions = set()
+
+    for sent in doc.sents:
+        sent_doc = nlp(sent.text)
+        
+        for ent in sent_doc.ents:
+            term = ent.text.strip()
+            definition = sent.text.strip()
+            if (
+                term and
+                len(term.split()) <= 4 and
+                term.lower() not in seen_terms and
+                definition not in seen_definitions and
+                len(definition) > len(term) + 10
+            ):
+                pairs.append({"term": term, "definition": definition})
+                seen_terms.add(term.lower())
+                seen_definitions.add(definition)
+                break
+
+        if len(pairs) >= max_pairs:
+            break
+
+    if len(pairs) < 3:
+        for sent in doc.sents:
+            sent_doc = nlp(sent.text)
+            for chunk in sent_doc.noun_chunks:
+                term = chunk.text.strip()
+                definition = sent.text.strip()
+                if (
+                    term and
+                    len(term.split()) <= 4 and
+                    term.lower() not in seen_terms and
+                    definition not in seen_definitions and
+                    len(definition) > len(term) + 10
+                ):
+                    pairs.append({"term": term, "definition": definition})
+                    seen_terms.add(term.lower())
+                    seen_definitions.add(definition)
+                    break
+            if len(pairs) >= max_pairs:
+                break
+
+    return pairs[:max_pairs]
+
+
+def generate_match_columns(payload):
+    text = payload.get("input_text", "")
+    max_pairs = payload.get("max_questions", 6)
+
+    pairs = extract_pairs_from_text(text, max_pairs)
+
+    if not pairs:
+        return {"pairs": [], "left_column": [], "right_column": []}
+
+    left_column = [p["term"] for p in pairs]
+    right_column = [p["definition"] for p in pairs]
+
+    shuffled_right = right_column.copy()
+    random.shuffle(shuffled_right)
+
+    return {
+        "pairs": pairs,
+        "left_column": left_column,
+        "right_column": shuffled_right
+    }

--- a/backend/server.py
+++ b/backend/server.py
@@ -25,6 +25,7 @@ from apiclient import discovery
 from httplib2 import Http
 from oauth2client import client, file, tools
 from mediawikiapi import MediaWikiAPI
+from Generator.match_columns import generate_match_columns
 
 app = Flask(__name__)
 CORS(app)
@@ -489,6 +490,23 @@ def get_transcript():
     os.remove(latest_subtitle)
 
     return jsonify({"transcript": transcript_text})
+
+    
+@app.route("/get_match_columns", methods=["POST"])
+def get_match_columns():
+    data = request.get_json()
+    input_text = data.get("input_text", "")
+    use_mediawiki = data.get("use_mediawiki", 0)
+    max_questions = data.get("max_questions", 6)
+    input_text = process_input_text(input_text, use_mediawiki)
+    
+    result = generate_match_columns({
+        "input_text": input_text,
+        "max_questions": max_questions
+    })
+    
+    return jsonify(result)
+
 
 if __name__ == "__main__":
     os.makedirs("subtitles", exist_ok=True)

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -18,11 +18,12 @@ const Output = () => {
 
   useEffect(() => {
     const handleClickOutside = (event) => {
-        const dropdown = document.getElementById('pdfDropdown');
-        if (dropdown && !dropdown.contains(event.target) && 
-            !event.target.closest('button')) {
-            dropdown.classList.add('hidden');
-        }
+      const dropdown = document.getElementById('pdfDropdown');
+      const isInsideDropdown = dropdown?.contains(event.target);
+      const isToggleButton = event.target.closest?.('#pdfDropdownToggle');
+      if (dropdown && !isInsideDropdown && !isToggleButton) {
+        dropdown.classList.add('hidden');
+      }
     };
 
     document.addEventListener('mousedown', handleClickOutside);
@@ -95,21 +96,22 @@ const Output = () => {
       JSON.parse(localStorage.getItem("qaPairs")) || {};
     if (qaPairsFromStorage) {
       const combinedQaPairs = [];
+      const outputQuestions = qaPairsFromStorage["output"];
+      const boolQuestions = qaPairsFromStorage["output_boolq"]?.["Boolean_Questions"];
+      const mcqQuestions = qaPairsFromStorage["output_mcq"]?.["questions"];
 
-      if (questionType === "get_problems" && qaPairsFromStorage["output_boolq"]) {
-        qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
-          (question) => {
-            combinedQaPairs.push({
-              question,
-              question_type: "Boolean",
-              context: qaPairsFromStorage["output_boolq"]["Text"],
-            });
-          }
-        );
+      if (questionType === "get_problems" && Array.isArray(boolQuestions)) {
+        boolQuestions.forEach((question) => {
+          combinedQaPairs.push({
+            question,
+            question_type: "Boolean",
+            context: qaPairsFromStorage["output_boolq"]["Text"],
+          });
+        });
       }
 
-      if (questionType === "get_problems" && qaPairsFromStorage["output_mcq"]) {
-        qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
+      if (questionType === "get_problems" && Array.isArray(mcqQuestions)) {
+        mcqQuestions.forEach((qaPair) => {
           combinedQaPairs.push({
             question: qaPair.question_statement,
             question_type: "MCQ",
@@ -120,8 +122,8 @@ const Output = () => {
         });
       }
 
-      if (questionType === "get_mcq" && qaPairsFromStorage["output"]) {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      if (questionType === "get_mcq" && Array.isArray(outputQuestions)) {
+        outputQuestions.forEach((qaPair) => {
           combinedQaPairs.push({
             question: qaPair.question_statement,
             question_type: "MCQ",
@@ -131,8 +133,12 @@ const Output = () => {
           });
         });
       } else if (questionType === "get_match_columns") {
-        const pairs = qaPairsFromStorage["pairs"] || [];
-        const shuffledRight = qaPairsFromStorage["right_column"] || [];
+        const pairs = Array.isArray(qaPairsFromStorage["pairs"])
+          ? qaPairsFromStorage["pairs"]
+          : [];
+        const shuffledRight = Array.isArray(qaPairsFromStorage["right_column"])
+          ? qaPairsFromStorage["right_column"]
+          : [];
 
         if (pairs.length > 0) {
           combinedQaPairs.push({
@@ -142,15 +148,15 @@ const Output = () => {
             right_column: shuffledRight,
           });
         }
-      } else if (questionType === "get_boolq" && qaPairsFromStorage["output"]) {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      } else if (questionType === "get_boolq" && Array.isArray(outputQuestions)) {
+        outputQuestions.forEach((qaPair) => {
           combinedQaPairs.push({
             question: qaPair,
             question_type: "Boolean",
           });
         });
-      } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
+      } else if (Array.isArray(outputQuestions) && questionType !== "get_mcq") {
+        outputQuestions.forEach((qaPair) => {
           combinedQaPairs.push({
             question:
               qaPair.question || qaPair.question_statement || qaPair.Question,
@@ -199,13 +205,15 @@ const Output = () => {
     worker.onmessage = (e) => {
       const blob = new Blob([e.data], { type: 'application/pdf' });
       const link = document.createElement('a');
-      link.href = URL.createObjectURL(blob);
+      const objectUrl = URL.createObjectURL(blob);
+      link.href = objectUrl;
       link.download = "generated_questions.pdf";
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
 
-      document.getElementById('pdfDropdown').classList.add('hidden');
+      document.getElementById('pdfDropdown')?.classList.add('hidden');
       worker.terminate();
     };
 
@@ -221,10 +229,10 @@ const Output = () => {
         <div className="flex flex-col h-full">
           <Link to="/">
             <div className="flex items-end gap-[2px] px-4 sm:px-6">
-              <img 
-                src={logoPNG} 
-                alt="logo" 
-                className="w-12 sm:w-16 my-4 block" 
+              <img
+                src={logoPNG}
+                alt="logo"
+                className="w-12 sm:w-16 my-4 block"
               />
               <div className="text-xl sm:text-2xl mb-3 font-extrabold">
                 <span className="bg-gradient-to-r from-[#FF005C] to-[#7600F2] text-transparent bg-clip-text">
@@ -260,7 +268,7 @@ const Output = () => {
               qaPairs.map((qaPair, index) => {
                 const shuffledOptions = shuffledOptionsMap[index];
                 const isEditing = editingIndex === index;
-                
+
                 return (
                   <div
                     key={index}
@@ -386,7 +394,7 @@ const Output = () => {
                           value={editedQuestion}
                           onChange={(e) => setEditedQuestion(e.target.value)}
                         />
-                        
+
                         {qaPair.question_type !== "Boolean" && (
                           <>
                             <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 mb-1">
@@ -398,7 +406,7 @@ const Output = () => {
                               value={editedAnswer}
                               onChange={(e) => setEditedAnswer(e.target.value)}
                             />
-                            
+
                             {editedOptions && editedOptions.length > 0 && (
                               <div className="mt-3">
                                 <div className="text-[#E4E4E4] text-xs sm:text-sm mb-2">
@@ -435,15 +443,16 @@ const Output = () => {
             >
               Generate Google form
             </button>
-            
+
             <div className="relative w-full sm:w-auto">
               <button
+                id="pdfDropdownToggle"
                 className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
                 onClick={() => document.getElementById('pdfDropdown').classList.toggle('hidden')}
               >
                 Generate PDF
               </button>
-              
+
               <div
                 id="pdfDropdown"
                 className="hidden absolute bottom-full mb-1 left-0 sm:left-auto right-0 sm:right-auto bg-[#02000F] shadow-md text-white rounded-lg shadow-lg z-50 w-full sm:w-48"

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -120,7 +120,7 @@ useEffect(() => {
       });
     }
 
-    if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq") {
+    if (questionType === "get_mcq" && qaPairsFromStorage["output"]) {
       qaPairsFromStorage["output"].forEach((qaPair) => {
         combinedQaPairs.push({
           question: qaPair.question_statement,

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -94,11 +94,10 @@ const Output = () => {
   useEffect(() => {
     const qaPairsFromStorage =
       JSON.parse(localStorage.getItem("qaPairs")) || {};
-    if (qaPairsFromStorage) {
-      const combinedQaPairs = [];
-      const outputQuestions = qaPairsFromStorage["output"];
-      const boolQuestions = qaPairsFromStorage["output_boolq"]?.["Boolean_Questions"];
-      const mcqQuestions = qaPairsFromStorage["output_mcq"]?.["questions"];
+    const combinedQaPairs = [];
+    const outputQuestions = qaPairsFromStorage["output"];
+    const boolQuestions = qaPairsFromStorage["output_boolq"]?.["Boolean_Questions"];
+    const mcqQuestions = qaPairsFromStorage["output_mcq"]?.["questions"];
 
       if (questionType === "get_problems" && Array.isArray(boolQuestions)) {
         boolQuestions.forEach((question) => {
@@ -169,7 +168,6 @@ const Output = () => {
       }
 
       setQaPairs(combinedQaPairs);
-    }
   }, [questionType]);
 
   const generateGoogleForm = async () => {

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -27,7 +27,7 @@ const Output = () => {
 
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-}, []);
+  }, []);
 
   function shuffleArray(array) {
     const shuffledArray = [...array];
@@ -90,83 +90,81 @@ const Output = () => {
     setEditedOptions(updatedOptions);
   };
 
-useEffect(() => {
-  const qaPairsFromStorage =
-    JSON.parse(localStorage.getItem("qaPairs")) || {};
-  if (qaPairsFromStorage) {
-    const combinedQaPairs = [];
+  useEffect(() => {
+    const qaPairsFromStorage =
+      JSON.parse(localStorage.getItem("qaPairs")) || {};
+    if (qaPairsFromStorage) {
+      const combinedQaPairs = [];
 
-    if (qaPairsFromStorage["output_boolq"]) {
-      qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
-        (question, index) => {
+      if (questionType === "get_problems" && qaPairsFromStorage["output_boolq"]) {
+        qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
+          (question) => {
+            combinedQaPairs.push({
+              question,
+              question_type: "Boolean",
+              context: qaPairsFromStorage["output_boolq"]["Text"],
+            });
+          }
+        );
+      }
+
+      if (questionType === "get_problems" && qaPairsFromStorage["output_mcq"]) {
+        qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
           combinedQaPairs.push({
-            question,
-            question_type: "Boolean",
-            context: qaPairsFromStorage["output_boolq"]["Text"],
+            question: qaPair.question_statement,
+            question_type: "MCQ",
+            options: qaPair.options,
+            answer: qaPair.answer,
+            context: qaPair.context,
           });
-        }
-      );
-    }
-
-    if (qaPairsFromStorage["output_mcq"]) {
-      qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
-        combinedQaPairs.push({
-          question: qaPair.question_statement,
-          question_type: "MCQ",
-          options: qaPair.options,
-          answer: qaPair.answer,
-          context: qaPair.context,
-        });
-      });
-    }
-
-    if (questionType === "get_mcq" && qaPairsFromStorage["output"]) {
-      qaPairsFromStorage["output"].forEach((qaPair) => {
-        combinedQaPairs.push({
-          question: qaPair.question_statement,
-          question_type: "MCQ",
-          options: qaPair.options,
-          answer: qaPair.answer,
-          context: qaPair.context,
-        });
-      });
-    } else if (questionType === "get_match_columns") {
-      // Handle Match the Columns question type
-      const pairs = qaPairsFromStorage["pairs"] || [];
-      const shuffledRight = qaPairsFromStorage["right_column"] || [];
-
-      if (pairs.length > 0) {
-        // Push a single special entry to represent the whole match table
-        combinedQaPairs.push({
-          question_type: "MatchColumns",
-          pairs: pairs,           // [{term, definition}, ...]
-          left_column: pairs.map((p) => p.term),
-          right_column: shuffledRight, // shuffled definitions from backend
         });
       }
-    } else if (questionType === "get_boolq") {
-      qaPairsFromStorage["output"].forEach((qaPair) => {
-        combinedQaPairs.push({
-          question: qaPair,
-          question_type: "Boolean",
-        });
-      });
-    } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
-      qaPairsFromStorage["output"].forEach((qaPair) => {
-        combinedQaPairs.push({
-          question:
-            qaPair.question || qaPair.question_statement || qaPair.Question,
-          options: qaPair.options,
-          answer: qaPair.answer || qaPair.Answer,
-          context: qaPair.context,
-          question_type: "Short",
-        });
-      });
-    }
 
-    setQaPairs(combinedQaPairs);
-  }
-}, [questionType]);
+      if (questionType === "get_mcq" && qaPairsFromStorage["output"]) {
+        qaPairsFromStorage["output"].forEach((qaPair) => {
+          combinedQaPairs.push({
+            question: qaPair.question_statement,
+            question_type: "MCQ",
+            options: qaPair.options,
+            answer: qaPair.answer,
+            context: qaPair.context,
+          });
+        });
+      } else if (questionType === "get_match_columns") {
+        const pairs = qaPairsFromStorage["pairs"] || [];
+        const shuffledRight = qaPairsFromStorage["right_column"] || [];
+
+        if (pairs.length > 0) {
+          combinedQaPairs.push({
+            question_type: "MatchColumns",
+            pairs: pairs,
+            left_column: pairs.map((p) => p.term),
+            right_column: shuffledRight,
+          });
+        }
+      } else if (questionType === "get_boolq" && qaPairsFromStorage["output"]) {
+        qaPairsFromStorage["output"].forEach((qaPair) => {
+          combinedQaPairs.push({
+            question: qaPair,
+            question_type: "Boolean",
+          });
+        });
+      } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
+        qaPairsFromStorage["output"].forEach((qaPair) => {
+          combinedQaPairs.push({
+            question:
+              qaPair.question || qaPair.question_statement || qaPair.Question,
+            options: qaPair.options,
+            answer: qaPair.answer || qaPair.Answer,
+            context: qaPair.context,
+            question_type: "Short",
+          });
+        });
+      }
+
+      setQaPairs(combinedQaPairs);
+    }
+  }, [questionType]);
 
   const generateGoogleForm = async () => {
     try {
@@ -192,7 +190,7 @@ useEffect(() => {
     }
   };
 
-    const generatePDF = async (mode) => {
+  const generatePDF = async (mode) => {
     const logoBytes = await loadLogoAsBytes();
     const worker = new Worker(new URL("../workers/pdfWorker.js", import.meta.url), { type: "module" });
 
@@ -218,271 +216,263 @@ useEffect(() => {
   };
 
   return (
-  <div className="popup w-full h-full bg-[#02000F] flex justify-center items-center">
-    <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient">
-      <div className="flex flex-col h-full">
-        {/* Header - Responsive logo and title */}
-        <Link to="/">
-          <div className="flex items-end gap-[2px] px-4 sm:px-6">
-            <img 
-              src={logoPNG} 
-              alt="logo" 
-              className="w-12 sm:w-16 my-4 block" 
-            />
-            <div className="text-xl sm:text-2xl mb-3 font-extrabold">
-              <span className="bg-gradient-to-r from-[#FF005C] to-[#7600F2] text-transparent bg-clip-text">
-                Edu
-              </span>
-              <span className="bg-gradient-to-r from-[#7600F2] to-[#00CBE7] text-transparent bg-clip-text">
-                Aid
-              </span>
+    <div className="popup w-full h-full bg-[#02000F] flex justify-center items-center">
+      <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient">
+        <div className="flex flex-col h-full">
+          <Link to="/">
+            <div className="flex items-end gap-[2px] px-4 sm:px-6">
+              <img 
+                src={logoPNG} 
+                alt="logo" 
+                className="w-12 sm:w-16 my-4 block" 
+              />
+              <div className="text-xl sm:text-2xl mb-3 font-extrabold">
+                <span className="bg-gradient-to-r from-[#FF005C] to-[#7600F2] text-transparent bg-clip-text">
+                  Edu
+                </span>
+                <span className="bg-gradient-to-r from-[#7600F2] to-[#00CBE7] text-transparent bg-clip-text">
+                  Aid
+                </span>
+              </div>
             </div>
-          </div>
-        </Link>
+          </Link>
 
-        {/* Title and Shuffle Button */}
-        <div className="flex justify-between items-center mt-3 mx-4 sm:mx-6">
-          <div className="font-bold text-lg sm:text-xl text-white">
-            Generated Questions
+          <div className="flex justify-between items-center mt-3 mx-4 sm:mx-6">
+            <div className="font-bold text-lg sm:text-xl text-white">
+              Generated Questions
+            </div>
+            <button
+              className={`${
+                editingIndex !== null
+                  ? 'bg-gray-500 cursor-not-allowed'
+                  : 'bg-[#7C3AED] hover:bg-[#5A2AD9]'
+              } text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors flex items-center gap-2`}
+              onClick={handleShuffleQuestions}
+              disabled={editingIndex !== null}
+            >
+              <FiShuffle className="text-sm sm:text-base" />
+              Shuffle
+            </button>
           </div>
-          <button
-            className={`${
-              editingIndex !== null
-                ? 'bg-gray-500 cursor-not-allowed'
-                : 'bg-[#7C3AED] hover:bg-[#5A2AD9]'
-            } text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors flex items-center gap-2`}
-            onClick={handleShuffleQuestions}
-            disabled={editingIndex !== null}
-          >
-            <FiShuffle className="text-sm sm:text-base" />
-            Shuffle
-          </button>
-        </div>
 
-        {/* Questions Container - Responsive padding and margins */}
-        <div className="flex-1 overflow-y-auto scrollbar-hide px-2 sm:px-4">
-          {qaPairs &&
-            qaPairs.map((qaPair, index) => {
-              const shuffledOptions = shuffledOptionsMap[index];
-              const isEditing = editingIndex === index;
-              
-              return (
-                <div
-                  key={index}
-                  className="px-3 sm:px-4 bg-[#d9d9d90d] border-black border my-2 sm:my-3 mx-1 sm:mx-2 rounded-xl py-3 sm:py-4"
-                >
-                  {/* ✅ CHANGE 1: Question label shows "Match the Columns" for MatchColumns type */}
-                  <div className="flex justify-between items-center mb-2">
-                    <div className="text-[#E4E4E4] text-xs sm:text-sm">
-                      {qaPair.question_type === "MatchColumns"
-                        ? "Match the Columns"
-                        : `Question ${index + 1}`}
+          <div className="flex-1 overflow-y-auto scrollbar-hide px-2 sm:px-4">
+            {qaPairs &&
+              qaPairs.map((qaPair, index) => {
+                const shuffledOptions = shuffledOptionsMap[index];
+                const isEditing = editingIndex === index;
+                
+                return (
+                  <div
+                    key={index}
+                    className="px-3 sm:px-4 bg-[#d9d9d90d] border-black border my-2 sm:my-3 mx-1 sm:mx-2 rounded-xl py-3 sm:py-4"
+                  >
+                    <div className="flex justify-between items-center mb-2">
+                      <div className="text-[#E4E4E4] text-xs sm:text-sm">
+                        {qaPair.question_type === "MatchColumns"
+                          ? "Match the Columns"
+                          : `Question ${index + 1}`}
+                      </div>
+
+                      {qaPair.question_type !== "MatchColumns" && (
+                        <>
+                          {!isEditing ? (
+                            <button
+                              className="bg-[#518E8E] hover:bg-[#3a6b6b] text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                              onClick={() => handleEditQuestion(index)}
+                            >
+                              <FiEdit2 className="text-sm sm:text-base" />
+                              Edit
+                            </button>
+                          ) : (
+                            <div className="flex gap-2">
+                              <button
+                                className="bg-green-700 hover:bg-green-800 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                                onClick={() => handleSaveQuestion(index)}
+                              >
+                                <FiCheck className="text-sm sm:text-base" />
+                                Save
+                              </button>
+                              <button
+                                className="bg-gray-600 hover:bg-gray-700 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                                onClick={handleCancelEdit}
+                              >
+                                <FiX className="text-sm sm:text-base" />
+                                Cancel
+                              </button>
+                            </div>
+                          )}
+                        </>
+                      )}
                     </div>
 
-                    {/* ✅ CHANGE 2: Hide Edit/Save/Cancel buttons for MatchColumns */}
-                    {qaPair.question_type !== "MatchColumns" && (
+                    {!isEditing ? (
                       <>
-                        {!isEditing ? (
-                          <button
-                            className="bg-[#518E8E] hover:bg-[#3a6b6b] text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                            onClick={() => handleEditQuestion(index)}
-                          >
-                            <FiEdit2 className="text-sm sm:text-base" />
-                            Edit
-                          </button>
-                        ) : (
-                          <div className="flex gap-2">
-                            <button
-                              className="bg-green-700 hover:bg-green-800 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                              onClick={() => handleSaveQuestion(index)}
-                            >
-                              <FiCheck className="text-sm sm:text-base" />
-                              Save
-                            </button>
-                            <button
-                              className="bg-gray-600 hover:bg-gray-700 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                              onClick={handleCancelEdit}
-                            >
-                              <FiX className="text-sm sm:text-base" />
-                              Cancel
-                            </button>
+                        {qaPair.question_type === "MatchColumns" ? (
+                          <div className="w-full mt-2">
+                            <div className="flex justify-between text-[#E4E4E4] text-xs sm:text-sm font-bold mb-3 px-2">
+                              <span className="flex-1 text-center">Column A (Terms)</span>
+                              <span className="flex-1 text-center">Column B (Definitions)</span>
+                            </div>
+                            {qaPair.left_column.map((term, i) => (
+                              <div key={i} className="flex justify-between gap-4 mb-2 px-2">
+                                <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
+                                  {i + 1}. {term}
+                                </div>
+                                <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
+                                  {String.fromCharCode(65 + i)}. {qaPair.right_column[i] ?? "—"}
+                                </div>
+                              </div>
+                            ))}
+
+                            {(() => {
+                              const answerMap = qaPair.pairs.map((pair) => {
+                                const idx = qaPair.right_column.indexOf(pair.definition);
+                                return idx >= 0 ? String.fromCharCode(65 + idx) : "?";
+                              });
+                              return (
+                                <div className="mt-4 px-2 border-t border-gray-700 pt-3">
+                                  <div className="text-[#E4E4E4] text-xs sm:text-sm font-bold mb-2">
+                                    Answer Key
+                                  </div>
+                                  {qaPair.pairs.map((pair, i) => (
+                                    <div key={i} className="text-[#FFF4F4] text-xs sm:text-sm mb-1">
+                                      {i + 1} → {answerMap[i]}
+                                    </div>
+                                  ))}
+                                </div>
+                              );
+                            })()}
                           </div>
+                        ) : (
+                          <>
+                            <div className="text-[#FFF4F4] text-sm sm:text-base my-1 sm:my-2 leading-relaxed">
+                              {qaPair.question}
+                            </div>
+                            {qaPair.question_type !== "Boolean" && (
+                              <>
+                                <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 sm:mt-4">
+                                  Answer
+                                </div>
+                                <div className="text-[#FFF4F4] text-sm sm:text-base leading-relaxed">
+                                  {qaPair.answer}
+                                </div>
+                                {qaPair.options && qaPair.options.length > 0 && (
+                                  <div className="text-[#FFF4F4] text-sm sm:text-base mt-2 sm:mt-3">
+                                    {shuffledOptions.map((option, idx) => (
+                                      <div key={idx} className="mb-1 sm:mb-2">
+                                        <span className="text-[#E4E4E4] text-xs sm:text-sm">
+                                          Option {idx + 1}:
+                                        </span>{" "}
+                                        <span className="text-[#FFF4F4] text-sm sm:text-base">
+                                          {option}
+                                        </span>
+                                      </div>
+                                    ))}
+                                  </div>
+                                )}
+                              </>
+                            )}
+                          </>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <div className="text-[#E4E4E4] text-xs sm:text-sm mb-1">
+                          Edit Question
+                        </div>
+                        <textarea
+                          className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
+                          rows="3"
+                          value={editedQuestion}
+                          onChange={(e) => setEditedQuestion(e.target.value)}
+                        />
+                        
+                        {qaPair.question_type !== "Boolean" && (
+                          <>
+                            <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 mb-1">
+                              Edit Answer
+                            </div>
+                            <textarea
+                              className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
+                              rows="2"
+                              value={editedAnswer}
+                              onChange={(e) => setEditedAnswer(e.target.value)}
+                            />
+                            
+                            {editedOptions && editedOptions.length > 0 && (
+                              <div className="mt-3">
+                                <div className="text-[#E4E4E4] text-xs sm:text-sm mb-2">
+                                  Edit Options
+                                </div>
+                                {editedOptions.map((option, optIdx) => (
+                                  <div key={optIdx} className="mb-2">
+                                    <div className="text-[#E4E4E4] text-xs mb-1">
+                                      Option {optIdx + 1}
+                                    </div>
+                                    <input
+                                      type="text"
+                                      className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none"
+                                      value={option}
+                                      onChange={(e) => handleOptionChange(optIdx, e.target.value)}
+                                    />
+                                  </div>
+                                ))}
+                              </div>
+                            )}
+                          </>
                         )}
                       </>
                     )}
                   </div>
+                );
+              })}
+          </div>
 
-                  {!isEditing ? (
-                    <>
-                      {qaPair.question_type === "MatchColumns" ? (
-                        <div className="w-full mt-2">
-                          <div className="flex justify-between text-[#E4E4E4] text-xs sm:text-sm font-bold mb-3 px-2">
-                            <span className="flex-1 text-center">Column A (Terms)</span>
-                            <span className="flex-1 text-center">Column B (Definitions)</span>
-                          </div>
-                          {qaPair.left_column.map((term, i) => (
-                            <div key={i} className="flex justify-between gap-4 mb-2 px-2">
-                              <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
-                                {i + 1}. {term}
-                              </div>
-                              <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
-                                {String.fromCharCode(65 + i)}. {qaPair.right_column[i]}
-                              </div>
-                            </div>
-                          ))}
-
-                        {/* Answer Key */}
-                        {(() => {
-                          const answerMap = qaPair.pairs.map((pair) => {
-                            const idx = qaPair.right_column.indexOf(pair.definition);
-                            return idx >= 0 ? String.fromCharCode(65 + idx) : "?";
-                          });
-                          return (
-                            <div className="mt-4 px-2 border-t border-gray-700 pt-3">
-                              <div className="text-[#E4E4E4] text-xs sm:text-sm font-bold mb-2">
-                                Answer Key
-                              </div>
-                              {qaPair.pairs.map((pair, i) => (
-                                <div key={i} className="text-[#FFF4F4] text-xs sm:text-sm mb-1">
-                                  {i + 1} → {answerMap[i]}
-                                </div>
-                              ))}
-                            </div>
-                          );
-                        })()}
-                        </div>
-                      ) : (
-                        <>
-                          <div className="text-[#FFF4F4] text-sm sm:text-base my-1 sm:my-2 leading-relaxed">
-                            {qaPair.question}
-                          </div>
-                          {qaPair.question_type !== "Boolean" && (
-                            <>
-                              <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 sm:mt-4">
-                                Answer
-                              </div>
-                              <div className="text-[#FFF4F4] text-sm sm:text-base leading-relaxed">
-                                {qaPair.answer}
-                              </div>
-                              {qaPair.options && qaPair.options.length > 0 && (
-                                <div className="text-[#FFF4F4] text-sm sm:text-base mt-2 sm:mt-3">
-                                  {shuffledOptions.map((option, idx) => (
-                                    <div key={idx} className="mb-1 sm:mb-2">
-                                      <span className="text-[#E4E4E4] text-xs sm:text-sm">
-                                        Option {idx + 1}:
-                                      </span>{" "}
-                                      <span className="text-[#FFF4F4] text-sm sm:text-base">
-                                        {option}
-                                      </span>
-                                    </div>
-                                  ))}
-                                </div>
-                              )}
-                            </>
-                          )}
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      <div className="text-[#E4E4E4] text-xs sm:text-sm mb-1">
-                        Edit Question
-                      </div>
-                      <textarea
-                        className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
-                        rows="3"
-                        value={editedQuestion}
-                        onChange={(e) => setEditedQuestion(e.target.value)}
-                      />
-                      
-                      {qaPair.question_type !== "Boolean" && (
-                        <>
-                          <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 mb-1">
-                            Edit Answer
-                          </div>
-                          <textarea
-                            className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
-                            rows="2"
-                            value={editedAnswer}
-                            onChange={(e) => setEditedAnswer(e.target.value)}
-                          />
-                          
-                          {editedOptions && editedOptions.length > 0 && (
-                            <div className="mt-3">
-                              <div className="text-[#E4E4E4] text-xs sm:text-sm mb-2">
-                                Edit Options
-                              </div>
-                              {editedOptions.map((option, optIdx) => (
-                                <div key={optIdx} className="mb-2">
-                                  <div className="text-[#E4E4E4] text-xs mb-1">
-                                    Option {optIdx + 1}
-                                  </div>
-                                  <input
-                                    type="text"
-                                    className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none"
-                                    value={option}
-                                    onChange={(e) => handleOptionChange(optIdx, e.target.value)}
-                                  />
-                                </div>
-                              ))}
-                            </div>
-                          )}
-                        </>
-                      )}
-                    </>
-                  )}
-                </div>
-              );
-            })}
-        </div>
-
-        {/* Action Buttons - Responsive layout */}
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 mx-4 sm:mx-auto pb-4 sm:pb-6">
-          <button
-            className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
-            onClick={generateGoogleForm}
-          >
-            Generate Google form
-          </button>
-          
-          <div className="relative w-full sm:w-auto">
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 mx-4 sm:mx-auto pb-4 sm:pb-6">
             <button
               className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
-              onClick={() => document.getElementById('pdfDropdown').classList.toggle('hidden')}
+              onClick={generateGoogleForm}
             >
-              Generate PDF
+              Generate Google form
             </button>
             
-            <div
-              id="pdfDropdown"
-              className="hidden absolute bottom-full mb-1 left-0 sm:left-auto right-0 sm:right-auto bg-[#02000F] shadow-md text-white rounded-lg shadow-lg z-50 w-full sm:w-48"
-            >
+            <div className="relative w-full sm:w-auto">
               <button
-                className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-t-lg text-sm sm:text-base"
-                onClick={() => generatePDF('questions')}
+                className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
+                onClick={() => document.getElementById('pdfDropdown').classList.toggle('hidden')}
               >
-                Questions Only
+                Generate PDF
               </button>
-              <button
-                className="block w-full text-left px-4 py-2 hover:bg-gray-500 text-sm sm:text-base"
-                onClick={() => generatePDF('questions_answers')}
+              
+              <div
+                id="pdfDropdown"
+                className="hidden absolute bottom-full mb-1 left-0 sm:left-auto right-0 sm:right-auto bg-[#02000F] shadow-md text-white rounded-lg shadow-lg z-50 w-full sm:w-48"
               >
-                Questions with Answers
-              </button>
-              <button
-                className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-b-lg text-sm sm:text-base"
-                onClick={() => generatePDF('answers')}
-              >
-                Answers Only
-              </button>
+                <button
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-t-lg text-sm sm:text-base"
+                  onClick={() => generatePDF('questions')}
+                >
+                  Questions Only
+                </button>
+                <button
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 text-sm sm:text-base"
+                  onClick={() => generatePDF('questions_answers')}
+                >
+                  Questions with Answers
+                </button>
+                <button
+                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-b-lg text-sm sm:text-base"
+                  onClick={() => generatePDF('answers')}
+                >
+                  Answers Only
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-);
+  );
 };
-
 
 export default Output;

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -331,19 +331,25 @@ useEffect(() => {
                             </div>
                           ))}
 
-                          {/* Answer Key */}
-                          <div className="mt-4 px-2 border-t border-gray-700 pt-3">
-                            <div className="text-[#E4E4E4] text-xs sm:text-sm font-bold mb-2">
-                              Answer Key
-                            </div>
-                            {qaPair.pairs.map((pair, i) => (
-                              <div key={i} className="text-[#FFF4F4] text-xs sm:text-sm mb-1">
-                                {i + 1} → {String.fromCharCode(
-                                  65 + qaPair.right_column.indexOf(pair.definition)
-                                )}
+                        {/* Answer Key */}
+                        {(() => {
+                          const answerMap = qaPair.pairs.map((pair) => {
+                            const idx = qaPair.right_column.indexOf(pair.definition);
+                            return idx >= 0 ? String.fromCharCode(65 + idx) : "?";
+                          });
+                          return (
+                            <div className="mt-4 px-2 border-t border-gray-700 pt-3">
+                              <div className="text-[#E4E4E4] text-xs sm:text-sm font-bold mb-2">
+                                Answer Key
                               </div>
-                            ))}
-                          </div>
+                              {qaPair.pairs.map((pair, i) => (
+                                <div key={i} className="text-[#FFF4F4] text-xs sm:text-sm mb-1">
+                                  {i + 1} → {answerMap[i]}
+                                </div>
+                              ))}
+                            </div>
+                          );
+                        })()}
                         </div>
                       ) : (
                         <>

--- a/eduaid_web/src/pages/Output.jsx
+++ b/eduaid_web/src/pages/Output.jsx
@@ -90,71 +90,83 @@ const Output = () => {
     setEditedOptions(updatedOptions);
   };
 
-  useEffect(() => {
-    const qaPairsFromStorage =
-      JSON.parse(localStorage.getItem("qaPairs")) || {};
-    if (qaPairsFromStorage) {
-      const combinedQaPairs = [];
+useEffect(() => {
+  const qaPairsFromStorage =
+    JSON.parse(localStorage.getItem("qaPairs")) || {};
+  if (qaPairsFromStorage) {
+    const combinedQaPairs = [];
 
-      if (qaPairsFromStorage["output_boolq"]) {
-        qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
-          (question, index) => {
-            combinedQaPairs.push({
-              question,
-              question_type: "Boolean",
-              context: qaPairsFromStorage["output_boolq"]["Text"],
-            });
-          }
-        );
-      }
-
-      if (qaPairsFromStorage["output_mcq"]) {
-        qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
+    if (qaPairsFromStorage["output_boolq"]) {
+      qaPairsFromStorage["output_boolq"]["Boolean_Questions"].forEach(
+        (question, index) => {
           combinedQaPairs.push({
-            question: qaPair.question_statement,
-            question_type: "MCQ",
-            options: qaPair.options,
-            answer: qaPair.answer,
-            context: qaPair.context,
-          });
-        });
-      }
-
-      if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question: qaPair.question_statement,
-            question_type: "MCQ",
-            options: qaPair.options,
-            answer: qaPair.answer,
-            context: qaPair.context,
-          });
-        });
-      }
-
-      if (questionType == "get_boolq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question: qaPair,
+            question,
             question_type: "Boolean",
+            context: qaPairsFromStorage["output_boolq"]["Text"],
           });
+        }
+      );
+    }
+
+    if (qaPairsFromStorage["output_mcq"]) {
+      qaPairsFromStorage["output_mcq"]["questions"].forEach((qaPair) => {
+        combinedQaPairs.push({
+          question: qaPair.question_statement,
+          question_type: "MCQ",
+          options: qaPair.options,
+          answer: qaPair.answer,
+          context: qaPair.context,
         });
-      } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
-        qaPairsFromStorage["output"].forEach((qaPair) => {
-          combinedQaPairs.push({
-            question:
-              qaPair.question || qaPair.question_statement || qaPair.Question,
-            options: qaPair.options,
-            answer: qaPair.answer || qaPair.Answer,
-            context: qaPair.context,
-            question_type: "Short",
-          });
+      });
+    }
+
+    if (qaPairsFromStorage["output_mcq"] || questionType === "get_mcq") {
+      qaPairsFromStorage["output"].forEach((qaPair) => {
+        combinedQaPairs.push({
+          question: qaPair.question_statement,
+          question_type: "MCQ",
+          options: qaPair.options,
+          answer: qaPair.answer,
+          context: qaPair.context,
+        });
+      });
+    } else if (questionType === "get_match_columns") {
+      // Handle Match the Columns question type
+      const pairs = qaPairsFromStorage["pairs"] || [];
+      const shuffledRight = qaPairsFromStorage["right_column"] || [];
+
+      if (pairs.length > 0) {
+        // Push a single special entry to represent the whole match table
+        combinedQaPairs.push({
+          question_type: "MatchColumns",
+          pairs: pairs,           // [{term, definition}, ...]
+          left_column: pairs.map((p) => p.term),
+          right_column: shuffledRight, // shuffled definitions from backend
         });
       }
-
-      setQaPairs(combinedQaPairs);
+    } else if (questionType === "get_boolq") {
+      qaPairsFromStorage["output"].forEach((qaPair) => {
+        combinedQaPairs.push({
+          question: qaPair,
+          question_type: "Boolean",
+        });
+      });
+    } else if (qaPairsFromStorage["output"] && questionType !== "get_mcq") {
+      qaPairsFromStorage["output"].forEach((qaPair) => {
+        combinedQaPairs.push({
+          question:
+            qaPair.question || qaPair.question_statement || qaPair.Question,
+          options: qaPair.options,
+          answer: qaPair.answer || qaPair.Answer,
+          context: qaPair.context,
+          question_type: "Short",
+        });
+      });
     }
-  }, []);
+
+    setQaPairs(combinedQaPairs);
+  }
+}, [questionType]);
 
   const generateGoogleForm = async () => {
     try {
@@ -206,220 +218,264 @@ const Output = () => {
   };
 
   return (
-    <div className="popup w-full h-full bg-[#02000F] flex justify-center items-center">
-      <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient">
-        <div className="flex flex-col h-full">
-          {/* Header - Responsive logo and title */}
-          <Link to="/">
-            <div className="flex items-end gap-[2px] px-4 sm:px-6">
-              <img 
-                src={logoPNG} 
-                alt="logo" 
-                className="w-12 sm:w-16 my-4 block" 
-              />
-              <div className="text-xl sm:text-2xl mb-3 font-extrabold">
-                <span className="bg-gradient-to-r from-[#FF005C] to-[#7600F2] text-transparent bg-clip-text">
-                  Edu
-                </span>
-                <span className="bg-gradient-to-r from-[#7600F2] to-[#00CBE7] text-transparent bg-clip-text">
-                  Aid
-                </span>
-              </div>
+  <div className="popup w-full h-full bg-[#02000F] flex justify-center items-center">
+    <div className="w-full h-full bg-cust bg-opacity-50 bg-custom-gradient">
+      <div className="flex flex-col h-full">
+        {/* Header - Responsive logo and title */}
+        <Link to="/">
+          <div className="flex items-end gap-[2px] px-4 sm:px-6">
+            <img 
+              src={logoPNG} 
+              alt="logo" 
+              className="w-12 sm:w-16 my-4 block" 
+            />
+            <div className="text-xl sm:text-2xl mb-3 font-extrabold">
+              <span className="bg-gradient-to-r from-[#FF005C] to-[#7600F2] text-transparent bg-clip-text">
+                Edu
+              </span>
+              <span className="bg-gradient-to-r from-[#7600F2] to-[#00CBE7] text-transparent bg-clip-text">
+                Aid
+              </span>
             </div>
-          </Link>
-
-          {/* Title and Shuffle Button */}
-          <div className="flex justify-between items-center mt-3 mx-4 sm:mx-6">
-            <div className="font-bold text-lg sm:text-xl text-white">
-              Generated Questions
-            </div>
-            <button
-              className={`${
-                editingIndex !== null
-                  ? 'bg-gray-500 cursor-not-allowed'
-                  : 'bg-[#7C3AED] hover:bg-[#5A2AD9]'
-              } text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors flex items-center gap-2`}
-              onClick={handleShuffleQuestions}
-              disabled={editingIndex !== null}
-            >
-              <FiShuffle className="text-sm sm:text-base" />
-              Shuffle
-            </button>
           </div>
+        </Link>
 
-          {/* Questions Container - Responsive padding and margins */}
-          <div className="flex-1 overflow-y-auto scrollbar-hide px-2 sm:px-4">
-            {qaPairs &&
-              qaPairs.map((qaPair, index) => {
-                const shuffledOptions = shuffledOptionsMap[index];
-                const isEditing = editingIndex === index;
-                
-                return (
-                  <div
-                    key={index}
-                    className="px-3 sm:px-4 bg-[#d9d9d90d] border-black border my-2 sm:my-3 mx-1 sm:mx-2 rounded-xl py-3 sm:py-4"
-                  >
-                    <div className="flex justify-between items-center mb-2">
-                      <div className="text-[#E4E4E4] text-xs sm:text-sm">
-                        Question {index + 1}
-                      </div>
-                      {!isEditing ? (
-                        <button
-                          className="bg-[#518E8E] hover:bg-[#3a6b6b] text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                          onClick={() => handleEditQuestion(index)}
-                        >
-                          <FiEdit2 className="text-sm sm:text-base" />
-                          Edit
-                        </button>
-                      ) : (
-                        <div className="flex gap-2">
-                          <button
-                            className="bg-green-700 hover:bg-green-800 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                            onClick={() => handleSaveQuestion(index)}
-                          >
-                            <FiCheck className="text-sm sm:text-base" />
-                            Save
-                          </button>
-                          <button
-                            className="bg-gray-600 hover:bg-gray-700 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
-                            onClick={handleCancelEdit}
-                          >
-                            <FiX className="text-sm sm:text-base" />
-                            Cancel
-                          </button>
-                        </div>
-                      )}
+        {/* Title and Shuffle Button */}
+        <div className="flex justify-between items-center mt-3 mx-4 sm:mx-6">
+          <div className="font-bold text-lg sm:text-xl text-white">
+            Generated Questions
+          </div>
+          <button
+            className={`${
+              editingIndex !== null
+                ? 'bg-gray-500 cursor-not-allowed'
+                : 'bg-[#7C3AED] hover:bg-[#5A2AD9]'
+            } text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors flex items-center gap-2`}
+            onClick={handleShuffleQuestions}
+            disabled={editingIndex !== null}
+          >
+            <FiShuffle className="text-sm sm:text-base" />
+            Shuffle
+          </button>
+        </div>
+
+        {/* Questions Container - Responsive padding and margins */}
+        <div className="flex-1 overflow-y-auto scrollbar-hide px-2 sm:px-4">
+          {qaPairs &&
+            qaPairs.map((qaPair, index) => {
+              const shuffledOptions = shuffledOptionsMap[index];
+              const isEditing = editingIndex === index;
+              
+              return (
+                <div
+                  key={index}
+                  className="px-3 sm:px-4 bg-[#d9d9d90d] border-black border my-2 sm:my-3 mx-1 sm:mx-2 rounded-xl py-3 sm:py-4"
+                >
+                  {/* ✅ CHANGE 1: Question label shows "Match the Columns" for MatchColumns type */}
+                  <div className="flex justify-between items-center mb-2">
+                    <div className="text-[#E4E4E4] text-xs sm:text-sm">
+                      {qaPair.question_type === "MatchColumns"
+                        ? "Match the Columns"
+                        : `Question ${index + 1}`}
                     </div>
 
-                    {!isEditing ? (
+                    {/* ✅ CHANGE 2: Hide Edit/Save/Cancel buttons for MatchColumns */}
+                    {qaPair.question_type !== "MatchColumns" && (
                       <>
-                        <div className="text-[#FFF4F4] text-sm sm:text-base my-1 sm:my-2 leading-relaxed">
-                          {qaPair.question}
-                        </div>
-                        {qaPair.question_type !== "Boolean" && (
-                          <>
-                            <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 sm:mt-4">
-                              Answer
-                            </div>
-                            <div className="text-[#FFF4F4] text-sm sm:text-base leading-relaxed">
-                              {qaPair.answer}
-                            </div>
-                            {qaPair.options && qaPair.options.length > 0 && (
-                              <div className="text-[#FFF4F4] text-sm sm:text-base mt-2 sm:mt-3">
-                                {shuffledOptions.map((option, idx) => (
-                                  <div key={idx} className="mb-1 sm:mb-2">
-                                    <span className="text-[#E4E4E4] text-xs sm:text-sm">
-                                      Option {idx + 1}:
-                                    </span>{" "}
-                                    <span className="text-[#FFF4F4] text-sm sm:text-base">
-                                      {option}
-                                    </span>
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                          </>
-                        )}
-                      </>
-                    ) : (
-                      <>
-                        <div className="text-[#E4E4E4] text-xs sm:text-sm mb-1">
-                          Edit Question
-                        </div>
-                        <textarea
-                          className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
-                          rows="3"
-                          value={editedQuestion}
-                          onChange={(e) => setEditedQuestion(e.target.value)}
-                        />
-                        
-                        {qaPair.question_type !== "Boolean" && (
-                          <>
-                            <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 mb-1">
-                              Edit Answer
-                            </div>
-                            <textarea
-                              className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
-                              rows="2"
-                              value={editedAnswer}
-                              onChange={(e) => setEditedAnswer(e.target.value)}
-                            />
-                            
-                            {editedOptions && editedOptions.length > 0 && (
-                              <div className="mt-3">
-                                <div className="text-[#E4E4E4] text-xs sm:text-sm mb-2">
-                                  Edit Options
-                                </div>
-                                {editedOptions.map((option, optIdx) => (
-                                  <div key={optIdx} className="mb-2">
-                                    <div className="text-[#E4E4E4] text-xs mb-1">
-                                      Option {optIdx + 1}
-                                    </div>
-                                    <input
-                                      type="text"
-                                      className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none"
-                                      value={option}
-                                      onChange={(e) => handleOptionChange(optIdx, e.target.value)}
-                                    />
-                                  </div>
-                                ))}
-                              </div>
-                            )}
-                          </>
+                        {!isEditing ? (
+                          <button
+                            className="bg-[#518E8E] hover:bg-[#3a6b6b] text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                            onClick={() => handleEditQuestion(index)}
+                          >
+                            <FiEdit2 className="text-sm sm:text-base" />
+                            Edit
+                          </button>
+                        ) : (
+                          <div className="flex gap-2">
+                            <button
+                              className="bg-green-700 hover:bg-green-800 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                              onClick={() => handleSaveQuestion(index)}
+                            >
+                              <FiCheck className="text-sm sm:text-base" />
+                              Save
+                            </button>
+                            <button
+                              className="bg-gray-600 hover:bg-gray-700 text-white px-3 sm:px-4 py-1.5 sm:py-2 rounded-lg text-xs sm:text-sm font-semibold transition-colors shadow-sm flex items-center gap-2"
+                              onClick={handleCancelEdit}
+                            >
+                              <FiX className="text-sm sm:text-base" />
+                              Cancel
+                            </button>
+                          </div>
                         )}
                       </>
                     )}
                   </div>
-                );
-              })}
-          </div>
 
-          {/* Action Buttons - Responsive layout */}
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 mx-4 sm:mx-auto pb-4 sm:pb-6">
+                  {!isEditing ? (
+                    <>
+                      {qaPair.question_type === "MatchColumns" ? (
+                        <div className="w-full mt-2">
+                          <div className="flex justify-between text-[#E4E4E4] text-xs sm:text-sm font-bold mb-3 px-2">
+                            <span className="flex-1 text-center">Column A (Terms)</span>
+                            <span className="flex-1 text-center">Column B (Definitions)</span>
+                          </div>
+                          {qaPair.left_column.map((term, i) => (
+                            <div key={i} className="flex justify-between gap-4 mb-2 px-2">
+                              <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
+                                {i + 1}. {term}
+                              </div>
+                              <div className="text-[#FFF4F4] text-sm flex-1 bg-[#1a1a2e] p-2 rounded border border-gray-700">
+                                {String.fromCharCode(65 + i)}. {qaPair.right_column[i]}
+                              </div>
+                            </div>
+                          ))}
+
+                          {/* Answer Key */}
+                          <div className="mt-4 px-2 border-t border-gray-700 pt-3">
+                            <div className="text-[#E4E4E4] text-xs sm:text-sm font-bold mb-2">
+                              Answer Key
+                            </div>
+                            {qaPair.pairs.map((pair, i) => (
+                              <div key={i} className="text-[#FFF4F4] text-xs sm:text-sm mb-1">
+                                {i + 1} → {String.fromCharCode(
+                                  65 + qaPair.right_column.indexOf(pair.definition)
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="text-[#FFF4F4] text-sm sm:text-base my-1 sm:my-2 leading-relaxed">
+                            {qaPair.question}
+                          </div>
+                          {qaPair.question_type !== "Boolean" && (
+                            <>
+                              <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 sm:mt-4">
+                                Answer
+                              </div>
+                              <div className="text-[#FFF4F4] text-sm sm:text-base leading-relaxed">
+                                {qaPair.answer}
+                              </div>
+                              {qaPair.options && qaPair.options.length > 0 && (
+                                <div className="text-[#FFF4F4] text-sm sm:text-base mt-2 sm:mt-3">
+                                  {shuffledOptions.map((option, idx) => (
+                                    <div key={idx} className="mb-1 sm:mb-2">
+                                      <span className="text-[#E4E4E4] text-xs sm:text-sm">
+                                        Option {idx + 1}:
+                                      </span>{" "}
+                                      <span className="text-[#FFF4F4] text-sm sm:text-base">
+                                        {option}
+                                      </span>
+                                    </div>
+                                  ))}
+                                </div>
+                              )}
+                            </>
+                          )}
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <div className="text-[#E4E4E4] text-xs sm:text-sm mb-1">
+                        Edit Question
+                      </div>
+                      <textarea
+                        className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
+                        rows="3"
+                        value={editedQuestion}
+                        onChange={(e) => setEditedQuestion(e.target.value)}
+                      />
+                      
+                      {qaPair.question_type !== "Boolean" && (
+                        <>
+                          <div className="text-[#E4E4E4] text-xs sm:text-sm mt-3 mb-1">
+                            Edit Answer
+                          </div>
+                          <textarea
+                            className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none resize-none"
+                            rows="2"
+                            value={editedAnswer}
+                            onChange={(e) => setEditedAnswer(e.target.value)}
+                          />
+                          
+                          {editedOptions && editedOptions.length > 0 && (
+                            <div className="mt-3">
+                              <div className="text-[#E4E4E4] text-xs sm:text-sm mb-2">
+                                Edit Options
+                              </div>
+                              {editedOptions.map((option, optIdx) => (
+                                <div key={optIdx} className="mb-2">
+                                  <div className="text-[#E4E4E4] text-xs mb-1">
+                                    Option {optIdx + 1}
+                                  </div>
+                                  <input
+                                    type="text"
+                                    className="w-full bg-[#1a1a2e] text-[#FFF4F4] text-sm sm:text-base p-2 rounded border border-gray-600 focus:border-[#7600F2] focus:outline-none"
+                                    value={option}
+                                    onChange={(e) => handleOptionChange(optIdx, e.target.value)}
+                                  />
+                                </div>
+                              ))}
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+
+        {/* Action Buttons - Responsive layout */}
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 mx-4 sm:mx-auto pb-4 sm:pb-6">
+          <button
+            className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
+            onClick={generateGoogleForm}
+          >
+            Generate Google form
+          </button>
+          
+          <div className="relative w-full sm:w-auto">
             <button
               className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
-              onClick={generateGoogleForm}
+              onClick={() => document.getElementById('pdfDropdown').classList.toggle('hidden')}
             >
-              Generate Google form
+              Generate PDF
             </button>
             
-            <div className="relative w-full sm:w-auto">
+            <div
+              id="pdfDropdown"
+              className="hidden absolute bottom-full mb-1 left-0 sm:left-auto right-0 sm:right-auto bg-[#02000F] shadow-md text-white rounded-lg shadow-lg z-50 w-full sm:w-48"
+            >
               <button
-                className="bg-[#518E8E] items-center flex gap-1 w-full sm:w-auto font-semibold text-white px-4 sm:px-6 py-3 sm:py-2 rounded-xl text-sm sm:text-base hover:bg-[#3a6b6b] transition-colors justify-center"
-                onClick={() => document.getElementById('pdfDropdown').classList.toggle('hidden')}
+                className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-t-lg text-sm sm:text-base"
+                onClick={() => generatePDF('questions')}
               >
-                Generate PDF
+                Questions Only
               </button>
-              
-              <div
-                id="pdfDropdown"
-                className="hidden absolute bottom-full mb-1 left-0 sm:left-auto right-0 sm:right-auto bg-[#02000F] shadow-md text-white rounded-lg shadow-lg z-50 w-full sm:w-48"
+              <button
+                className="block w-full text-left px-4 py-2 hover:bg-gray-500 text-sm sm:text-base"
+                onClick={() => generatePDF('questions_answers')}
               >
-                <button
-                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-t-lg text-sm sm:text-base"
-                  onClick={() => generatePDF('questions')}
-                >
-                  Questions Only
-                </button>
-                <button
-                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 text-sm sm:text-base"
-                  onClick={() => generatePDF('questions_answers')}
-                >
-                  Questions with Answers
-                </button>
-                <button
-                  className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-b-lg text-sm sm:text-base"
-                  onClick={() => generatePDF('answers')}
-                >
-                  Answers Only
-                </button>
-              </div>
+                Questions with Answers
+              </button>
+              <button
+                className="block w-full text-left px-4 py-2 hover:bg-gray-500 rounded-b-lg text-sm sm:text-base"
+                onClick={() => generatePDF('answers')}
+              >
+                Answers Only
+              </button>
             </div>
           </div>
         </div>
       </div>
     </div>
-  );
+  </div>
+);
 };
 
 

--- a/eduaid_web/src/pages/Question_Type.jsx
+++ b/eduaid_web/src/pages/Question_Type.jsx
@@ -52,6 +52,7 @@ const Question_Type = () => {
             { id: "get_shortq", label: "Short-Answer Type Questions" },
             { id: "get_mcq", label: "Multiple Choice Questions" },
             { id: "get_boolq", label: "True/False Questions" },
+            { id: "get_match_columns", label: "Match the Columns" },
             { id: "get_problems", label: "All Questions" },
           ].map((option) => (
             <div

--- a/eduaid_web/src/workers/pdfWorker.js
+++ b/eduaid_web/src/workers/pdfWorker.js
@@ -78,6 +78,89 @@ self.onmessage = async (e) => {
   }
 
   for (const qaPair of qaPairs) {
+
+    if (qaPair.question_type === "MatchColumns") {
+      const pairs = qaPair.pairs || [];
+      const rightColumn = qaPair.right_column || [];
+
+      const requiredHeight = 40 + pairs.length * 30 + 20 + pairs.length * 20 + 20;
+      createNewPageIfNeeded(requiredHeight);
+
+      page.drawText("Match the Columns", {
+        x: margin,
+        y,
+        size: 14,
+        color: rgb(0.2, 0.2, 0.8)
+      });
+      y -= 25;
+
+      const colWidth = (maxContentWidth - 20) / 2;
+
+      page.drawText("Column A (Terms)", {
+        x: margin,
+        y,
+        size: 11,
+        color: rgb(0, 0, 0)
+      });
+      page.drawText("Column B (Definitions)", {
+        x: margin + colWidth + 20,
+        y,
+        size: 11,
+        color: rgb(0, 0, 0)
+      });
+      y -= 20;
+
+      pairs.forEach((pair, i) => {
+        createNewPageIfNeeded(30);
+
+        page.drawText(`${i + 1}. ${pair.term}`, {
+          x: margin,
+          y,
+          size: 11
+        });
+
+        const defLabel = String.fromCharCode(65 + i);
+        const defLines = wrapText(`${defLabel}. ${rightColumn[i]}`, colWidth);
+        defLines.forEach((line, lineIdx) => {
+          page.drawText(line, {
+            x: margin + colWidth + 20,
+            y: y - lineIdx * 15,
+            size: 11
+          });
+        });
+
+        y -= Math.max(20, defLines.length * 15) + 5;
+      });
+
+      if (mode === 'questions_answers' || mode === 'answers') {
+        y -= 10;
+        createNewPageIfNeeded(20 + pairs.length * 18);
+
+        page.drawText("Answer Key", {
+          x: margin,
+          y,
+          size: 11,
+          color: rgb(0, 0.5, 0)
+        });
+        y -= 18;
+
+        pairs.forEach((pair, i) => {
+          const correctIndex = rightColumn.indexOf(pair.definition);
+          const letter = String.fromCharCode(65 + correctIndex);
+          page.drawText(`${i + 1} → ${letter}`, {
+            x: margin,
+            y,
+            size: 11,
+            color: rgb(0, 0.5, 0)
+          });
+          y -= 18;
+        });
+      }
+
+      y -= 20;
+      continue;
+    }
+
     let requiredHeight = 60;
     const questionLines = wrapText(qaPair.question, maxContentWidth);
     requiredHeight += questionLines.length * 20;


### PR DESCRIPTION
Closes #217

## What's Changed

Added a new Match-the-Columns question type to EduAid as discussed in #217.

Users can now select "Match the Columns" from the question type screen, paste their study material, and get a two-column quiz where terms on the left need to be matched with their definitions on the right. The right column is shuffled to make it an actual challenge. An answer key is shown at the bottom for self-checking.

## Changes

**Backend**
- Created `backend/Generator/match_columns.py` which extracts key terms and their context sentences from input text using spaCy NER, with a noun chunk fallback for texts with fewer named entities. Duplicate definitions are filtered out to ensure each row in the quiz is unique.
- Added a `/get_match_columns` POST endpoint in `server.py` that accepts input text and max question count, and returns the term pairs, left column, and shuffled right column.

**Frontend**
- Added "Match the Columns" as a selectable option in `Question_Type.jsx`
- Updated `Output.jsx` to render the two-column table layout with an answer key when this question type is selected. The Edit button is hidden for this type since the output is a single unified table rather than individual questions.

## PDF Export
- Added full PDF export support for Match-the-Columns questions in `pdfWorker.js`, including proper two-column layout rendering and answer key generation.

## Screenshots

<img width="1858" height="822" alt="image" src="https://github.com/user-attachments/assets/538f24a3-1ef1-43b9-8d32-7d039e66347d" />
<img width="1898" height="822" alt="image" src="https://github.com/user-attachments/assets/52ce9236-9019-43c9-8ca4-13b0c94d5901" />
<img width="1919" height="723" alt="image" src="https://github.com/user-attachments/assets/20414be2-7fe6-456d-926b-5b80c4266ead" />


## Testing
Verified the `/get_match_columns` endpoint locally using a test script. The endpoint correctly extracts unique term-definition pairs, shuffles the right column, and returns a valid answer key mapping.

Endpoint working!
LEFT COLUMN (Terms):
  1. Photosynthesis
  2. Mitochondria
  3. Chlorophyll
  4. DNA
CORRECT PAIRS (Answer Key):
  1 → E | Photosynthesis
  2 → D | Mitochondria
  3 → C | Chlorophyll
  4 → A | DNA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added "Match the Columns" question type with two-column Terms vs. Definitions and inline answer key.
  - Backend endpoint to generate matching-column exercises from input text.
  - PDF export now renders matching-column questions and optional answer key.

* **UI Improvements**
  - Dedicated rendering/layout for Match the Columns; per-item edit controls hidden for this type.
  - Question-type selector includes "Match the Columns" and PDF dropdown updated for download handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->