### PR TITLE
feat(eduaid_web): add API base fallback and backend connection status

### DIFF
--- a/eduaid_web/src/App.css
+++ b/eduaid_web/src/App.css
@@ -36,3 +36,37 @@
     transform: rotate(360deg);
   }
 }
+
+.connection-banner {
+  padding: 8px 12px;
+  text-align: center;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+}
+
+.connection-banner.down {
+  background: #b91c1c;
+  color: white;
+}
+
+.connection-banner.error {
+  background: #facc15;
+  color: #111827;
+}
+
+.connection-banner-retry {
+  background: #ffffff;
+  color: #b91c1c;
+  border: none;
+  padding: 4px 8px;
+  cursor: pointer;
+  border-radius: 4px;
+  font-size: 0.85rem;
+}
+
+.connection-banner-retry:hover {
+  filter: brightness(0.95);
+}

--- a/eduaid_web/src/App.js
+++ b/eduaid_web/src/App.js
@@ -1,4 +1,5 @@
 import "./App.css";
+import { useEffect, useState } from "react";
 import { Routes, Route, HashRouter } from "react-router-dom";
 import Home from "./pages/Home";
 import Question_Type from "./pages/Question_Type";
@@ -6,19 +7,60 @@ import Text_Input from "./pages/Text_Input";
 import Output from "./pages/Output";
 import Previous from "./pages/Previous";
 import NotFound from "./pages/PageNotFound";
+import apiClient from "./utils/apiClient";
+
+const initialConnectionState = { status: "unknown", detail: "" };
+
+function ConnectionBanner({ connection }) {
+  if (connection.status === "down") {
+    return (
+      <div className="connection-banner down">
+        <span>
+          Backend disconnected.{" "}
+          {connection.detail || "Please check backend server and API URL."}
+        </span>
+        <button
+          type="button"
+          className="connection-banner-retry"
+          onClick={() => window.location.reload()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (connection.status === "error") {
+    return (
+      <div className="connection-banner error">
+        Backend responded with an error.{" "}
+        {connection.detail || "Please try again shortly."}
+      </div>
+    );
+  }
+
+  return null;
+}
 
 function App() {
+  const [connection, setConnection] = useState(initialConnectionState);
+
+  useEffect(() => apiClient.subscribeConnectionStatus(setConnection), []);
+
   return (
-    <HashRouter>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/question-type" element={<Question_Type />} />
-        <Route path="/input" element={<Text_Input />} />
-        <Route path="/output" element={<Output />} />
-        <Route path="/history" element={<Previous />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </HashRouter>
+    <>
+      <ConnectionBanner connection={connection} />
+      <HashRouter>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/question-type" element={<Question_Type />} />
+          <Route path="/input" element={<Text_Input />} />
+          <Route path="/output" element={<Output />} />
+          <Route path="/history" element={<Previous />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </HashRouter>
+    </>
   );
 }
 

--- a/eduaid_web/src/utils/apiClient.js
+++ b/eduaid_web/src/utils/apiClient.js
@@ -11,6 +11,25 @@ class ApiClient {
     this.currentDetail = "";
   }
 
+  createHttpError(status, responseBody = "") {
+    const error = new Error(`HTTP ${status}`);
+    error.isHttpError = true;
+    error.status = status;
+    error.responseBody = responseBody;
+    return error;
+  }
+
+  getConnectionFailureDetail(baseUrl = this.baseUrl) {
+    return `Cannot reach backend at ${baseUrl}. Check server and API URL.`;
+  }
+
+  getBackendErrorDetail(status) {
+    if (status) {
+      return `Backend is reachable but returned HTTP ${status}.`;
+    }
+    return "Backend is reachable but returned an unexpected response.";
+  }
+
   subscribeConnectionStatus(listener) {
     this.listeners.add(listener);
     try {
@@ -45,22 +64,23 @@ class ApiClient {
     const host = window.location.hostname;
     if (host !== "localhost" && host !== "127.0.0.1") return [];
 
-    if (this.baseUrl.includes(":5000")) return ["http://localhost:5001"];
-    if (this.baseUrl.includes(":5001")) return ["http://localhost:5000"];
+    if (this.baseUrl.includes(":5000")) return [`http://${host}:5001`];
+    if (this.baseUrl.includes(":5001")) return [`http://${host}:5000`];
     return [];
   }
 
   async parseJsonResponse(response) {
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      throw new Error(`HTTP ${response.status}: ${text || "Request Failed"}`);
+      throw this.createHttpError(response.status, text);
     }
 
     if (response.status === 204 || response.status === 205) return null;
 
     const contentLength = response.headers.get("Content-Length");
-    if (contentLength === "0") return null;
-    return response.json();
+    const contentType = response.headers.get("Content-Type");
+    if (contentLength === "0" || !contentType) return null;
+    return await response.json();
   }
 
   async fetchJson(url, options = {}) {
@@ -68,44 +88,78 @@ class ApiClient {
     return this.parseJsonResponse(response);
   }
 
-  async requestWithFallback(endpoint, options = {}) {
-    const primaryUrl = `${this.baseUrl}${endpoint}`;
+  getCandidateBaseUrls() {
+    return [this.baseUrl, ...this.getFallbackBaseUrls().filter((url) => url !== this.baseUrl)];
+  }
 
-    try {
-      const data = await this.fetchJson(primaryUrl, options);
-      this.setConnectionStatus("up");
-      return data;
-    } catch (error) {
-      const isNetworkError = error instanceof TypeError;
-      if (!isNetworkError) {
-        this.setConnectionStatus("error", error.message);
-        throw error;
+  async probeConnection(baseUrl) {
+    if (this.isElectron) {
+      const response = await window.electronAPI.makeApiRequest("/", { method: "GET" });
+      if (!response.ok) {
+        throw this.createHttpError(response.status);
       }
+      return true;
+    }
 
-      const fallbackBaseUrls = this.getFallbackBaseUrls().filter(
-        (url) => url !== this.baseUrl
-      );
+    const response = await fetch(`${baseUrl}/`, { method: "GET" });
+    if (!response.ok) {
+      throw this.createHttpError(response.status);
+    }
+    return true;
+  }
 
-      for (const fallbackBaseUrl of fallbackBaseUrls) {
-        try {
-          const data = await this.fetchJson(`${fallbackBaseUrl}${endpoint}`, options);
-          this.baseUrl = fallbackBaseUrl;
-          this.setConnectionStatus("up");
-          return data;
-        } catch (fallbackError) {
-          if (!(fallbackError instanceof TypeError)) {
-            this.setConnectionStatus("error", fallbackError.message);
-            throw fallbackError;
-          }
+  async retryConnection() {
+    const candidateBaseUrls = this.getCandidateBaseUrls();
+    let lastError = null;
+
+    for (const baseUrl of candidateBaseUrls) {
+      try {
+        await this.probeConnection(baseUrl);
+        this.baseUrl = baseUrl;
+        this.setConnectionStatus("up");
+        return true;
+      } catch (error) {
+        lastError = error;
+        if (error?.isHttpError) {
+          this.baseUrl = baseUrl;
+          this.setConnectionStatus("error", this.getBackendErrorDetail(error.status));
+          return false;
         }
       }
-
-      this.setConnectionStatus(
-        "down",
-        `Cannot reach backend at ${this.baseUrl}. Check server and REACT_APP_BASE_URL.`
-      );
-      throw error;
     }
+
+    this.setConnectionStatus("down", this.getConnectionFailureDetail());
+    if (lastError) {
+      throw lastError;
+    }
+    throw new TypeError(this.getConnectionFailureDetail());
+  }
+
+  async requestWithFallback(endpoint, options = {}) {
+    const candidateBaseUrls = this.getCandidateBaseUrls();
+    let lastError = null;
+
+    for (const baseUrl of candidateBaseUrls) {
+      try {
+        const data = await this.fetchJson(`${baseUrl}${endpoint}`, options);
+        this.baseUrl = baseUrl;
+        this.setConnectionStatus("up");
+        return data;
+      } catch (error) {
+        lastError = error;
+        if (error?.isHttpError) {
+          this.baseUrl = baseUrl;
+          this.setConnectionStatus("up");
+          throw error;
+        }
+      }
+    }
+
+    this.setConnectionStatus("down", this.getConnectionFailureDetail());
+    if (lastError) {
+      throw lastError;
+    }
+    throw new TypeError(this.getConnectionFailureDetail());
   }
 
   async makeRequest(endpoint, options = {}) {
@@ -113,9 +167,12 @@ class ApiClient {
       try {
         const response = await window.electronAPI.makeApiRequest(endpoint, options);
         if (!response.ok) {
-          const err = new Error(`API request failed with status ${response.status}`);
-          err.isHttpError = true;
-          this.setConnectionStatus("error", err.message);
+          const responseBody =
+            typeof response.data === "string"
+              ? response.data
+              : JSON.stringify(response.data ?? "");
+          const err = this.createHttpError(response.status, responseBody);
+          this.setConnectionStatus("up");
           throw err;
         }
         this.setConnectionStatus("up");
@@ -124,7 +181,7 @@ class ApiClient {
         if (error?.isHttpError) {
           throw error;
         }
-        this.setConnectionStatus("down", error?.message || "API request failed");
+        this.setConnectionStatus("down", error?.message || this.getConnectionFailureDetail());
         throw error;
       }
     }
@@ -161,8 +218,11 @@ class ApiClient {
         this.setConnectionStatus("up");
         return data;
       } catch (error) {
-        const status = error instanceof TypeError ? "down" : "error";
-        this.setConnectionStatus(status, error?.message || "API request failed");
+        if (error?.isHttpError) {
+          this.setConnectionStatus("up");
+          throw error;
+        }
+        this.setConnectionStatus("down", error?.message || this.getConnectionFailureDetail());
         throw error;
       }
     }

--- a/eduaid_web/src/utils/apiClient.js
+++ b/eduaid_web/src/utils/apiClient.js
@@ -6,8 +6,6 @@ class ApiClient {
       ? window.electronAPI.getApiConfig().baseUrl
       : process.env.REACT_APP_BASE_URL || "http://localhost:5000";
 
-    this.fallbackBaseUrls = this.getFallbackBaseUrls();
-
     this.listeners = new Set();
     this.currentStatus = "unknown"; // unknown | up | down | error
     this.currentDetail = "";
@@ -74,7 +72,11 @@ class ApiClient {
         throw error;
       }
 
-      for (const fallbackBaseUrl of this.fallbackBaseUrls) {
+      const fallbackBaseUrls = this.getFallbackBaseUrls().filter(
+        (url) => url !== this.baseUrl
+      );
+
+      for (const fallbackBaseUrl of fallbackBaseUrls) {
         try {
           const data = await this.fetchJson(`${fallbackBaseUrl}${endpoint}`, options);
           this.baseUrl = fallbackBaseUrl;
@@ -102,13 +104,17 @@ class ApiClient {
         const response = await window.electronAPI.makeApiRequest(endpoint, options);
         if (!response.ok) {
           const err = new Error(`API request failed with status ${response.status}`);
+          err.isHttpError = true;
           this.setConnectionStatus("error", err.message);
           throw err;
         }
         this.setConnectionStatus("up");
         return response.data;
       } catch (error) {
-        this.setConnectionStatus("down", error.message);
+        if (error?.isHttpError) {
+          throw error;
+        }
+        this.setConnectionStatus("down", error?.message || "API request failed");
         throw error;
       }
     }

--- a/eduaid_web/src/utils/apiClient.js
+++ b/eduaid_web/src/utils/apiClient.js
@@ -13,6 +13,7 @@ class ApiClient {
 
   subscribeConnectionStatus(listener) {
     this.listeners.add(listener);
+    listener({ status: this.currentStatus, detail: this.currentDetail });
     return () => this.listeners.delete(listener);
   }
 

--- a/eduaid_web/src/utils/apiClient.js
+++ b/eduaid_web/src/utils/apiClient.js
@@ -13,7 +13,11 @@ class ApiClient {
 
   subscribeConnectionStatus(listener) {
     this.listeners.add(listener);
-    listener({ status: this.currentStatus, detail: this.currentDetail });
+    try {
+      listener({ status: this.currentStatus, detail: this.currentDetail });
+    } catch (error) {
+      console.error("Connection listener failed:", error);
+    }
     return () => this.listeners.delete(listener);
   }
 
@@ -51,6 +55,11 @@ class ApiClient {
       const text = await response.text().catch(() => "");
       throw new Error(`HTTP ${response.status}: ${text || "Request Failed"}`);
     }
+
+    if (response.status === 204 || response.status === 205) return null;
+
+    const contentLength = response.headers.get("Content-Length");
+    if (contentLength === "0") return null;
     return response.json();
   }
 
@@ -153,7 +162,7 @@ class ApiClient {
         return data;
       } catch (error) {
         const status = error instanceof TypeError ? "down" : "error";
-        this.setConnectionStatus(status, error.message);
+        this.setConnectionStatus(status, error?.message || "API request failed");
         throw error;
       }
     }

--- a/eduaid_web/src/utils/apiClient.js
+++ b/eduaid_web/src/utils/apiClient.js
@@ -1,89 +1,163 @@
 // API client that works both in web and Electron environments
 class ApiClient {
   constructor() {
-    this.isElectron = typeof window !== 'undefined' && window.electronAPI;
-    this.baseUrl = this.isElectron 
-      ? window.electronAPI.getApiConfig().baseUrl 
-      : process.env.REACT_APP_BASE_URL || 'http://localhost:5000';
+    this.isElectron = typeof window !== "undefined" && window.electronAPI;
+    this.baseUrl = this.isElectron
+      ? window.electronAPI.getApiConfig().baseUrl
+      : process.env.REACT_APP_BASE_URL || "http://localhost:5000";
+
+    this.fallbackBaseUrls = this.getFallbackBaseUrls();
+
+    this.listeners = new Set();
+    this.currentStatus = "unknown"; // unknown | up | down | error
+    this.currentDetail = "";
+  }
+
+  subscribeConnectionStatus(listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  notifyConnectionStatus(status, detail = "") {
+    this.listeners.forEach((listener) => {
+      try {
+        listener({ status, detail });
+      } catch (error) {
+        console.error("Connection listener failed:", error);
+      }
+    });
+  }
+
+  setConnectionStatus(status, detail = "") {
+    if (this.currentStatus === status && this.currentDetail === detail) return;
+    this.currentStatus = status;
+    this.currentDetail = detail;
+    this.notifyConnectionStatus(status, detail);
+  }
+
+  getFallbackBaseUrls() {
+    if (this.isElectron || process.env.REACT_APP_BASE_URL) return [];
+    if (typeof window === "undefined") return [];
+
+    const host = window.location.hostname;
+    if (host !== "localhost" && host !== "127.0.0.1") return [];
+
+    if (this.baseUrl.includes(":5000")) return ["http://localhost:5001"];
+    if (this.baseUrl.includes(":5001")) return ["http://localhost:5000"];
+    return [];
+  }
+
+  async parseJsonResponse(response) {
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${text || "Request Failed"}`);
+    }
+    return response.json();
+  }
+
+  async fetchJson(url, options = {}) {
+    const response = await fetch(url, options);
+    return this.parseJsonResponse(response);
+  }
+
+  async requestWithFallback(endpoint, options = {}) {
+    const primaryUrl = `${this.baseUrl}${endpoint}`;
+
+    try {
+      const data = await this.fetchJson(primaryUrl, options);
+      this.setConnectionStatus("up");
+      return data;
+    } catch (error) {
+      const isNetworkError = error instanceof TypeError;
+      if (!isNetworkError) {
+        this.setConnectionStatus("error", error.message);
+        throw error;
+      }
+
+      for (const fallbackBaseUrl of this.fallbackBaseUrls) {
+        try {
+          const data = await this.fetchJson(`${fallbackBaseUrl}${endpoint}`, options);
+          this.baseUrl = fallbackBaseUrl;
+          this.setConnectionStatus("up");
+          return data;
+        } catch (fallbackError) {
+          if (!(fallbackError instanceof TypeError)) {
+            this.setConnectionStatus("error", fallbackError.message);
+            throw fallbackError;
+          }
+        }
+      }
+
+      this.setConnectionStatus(
+        "down",
+        `Cannot reach backend at ${this.baseUrl}. Check server and REACT_APP_BASE_URL.`
+      );
+      throw error;
+    }
   }
 
   async makeRequest(endpoint, options = {}) {
     if (this.isElectron) {
-      // Use Electron's IPC for API requests
       try {
         const response = await window.electronAPI.makeApiRequest(endpoint, options);
-        if (response.ok) {
-          return response.data;
-        } else {
-          throw new Error(`API request failed with status ${response.status}`);
+        if (!response.ok) {
+          const err = new Error(`API request failed with status ${response.status}`);
+          this.setConnectionStatus("error", err.message);
+          throw err;
         }
+        this.setConnectionStatus("up");
+        return response.data;
       } catch (error) {
-        console.error('Electron API request failed:', error);
+        this.setConnectionStatus("down", error.message);
         throw error;
       }
-    } else {
-      // Use regular fetch for web environment
-      const url = `${this.baseUrl}${endpoint}`;
-      const response = await fetch(url, options);
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      return await response.json();
     }
+
+    return this.requestWithFallback(endpoint, options);
   }
 
   // Convenience methods for common HTTP verbs
   async get(endpoint, options = {}) {
-    return this.makeRequest(endpoint, { ...options, method: 'GET' });
+    return this.makeRequest(endpoint, { ...options, method: "GET" });
   }
 
   async post(endpoint, data, options = {}) {
     return this.makeRequest(endpoint, {
       ...options,
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        ...options.headers
+        "Content-Type": "application/json",
+        ...options.headers,
       },
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
     });
   }
 
   async postFormData(endpoint, formData, options = {}) {
     if (this.isElectron) {
-      // For Electron, we need to handle file uploads differently
-      // Since we can't easily pass files through IPC, we'll fall back to fetch
-      const url = `${this.baseUrl}${endpoint}`;
-      const response = await fetch(url, {
-        ...options,
-        method: 'POST',
-        body: formData
-      });
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
+      try {
+        const response = await fetch(`${this.baseUrl}${endpoint}`, {
+          ...options,
+          method: "POST",
+          body: formData,
+        });
+        const data = await this.parseJsonResponse(response);
+        this.setConnectionStatus("up");
+        return data;
+      } catch (error) {
+        const status = error instanceof TypeError ? "down" : "error";
+        this.setConnectionStatus(status, error.message);
+        throw error;
       }
-      
-      return await response.json();
-    } else {
-      // For web, use FormData directly
-      const url = `${this.baseUrl}${endpoint}`;
-      const response = await fetch(url, {
-        ...options,
-        method: 'POST',
-        body: formData
-      });
-      
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`);
-      }
-      
-      return await response.json();
     }
+
+    return this.requestWithFallback(endpoint, {
+      ...options,
+      method: "POST",
+      body: formData,
+    });
   }
 }
 
-// Export a singleton instance
-export default new ApiClient();
+const apiClient = new ApiClient();
+export default apiClient;


### PR DESCRIPTION
### Addressed Issues:
Fixes #509 

### Additional Notes:
- Added connection-status reporting in `apiClient` (`unknown | up | down | error`).
- Added local fallback from `localhost:5000` to `localhost:5001` (and reverse) when `REACT_APP_BASE_URL` is not set.
- Added top-level connection banner in `App.js`:
1. `down` state: backend unreachable + Retry button
2. `error` state: backend reachable but request failed (4xx/5xx)
- Kept this PR scoped to issue #509 only (no ErrorBoundary feature changes).
- Verified with `npm run build` (build succeeds; existing repo warnings remain).

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [ ] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.

## AI Usage Disclosure

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: Codex (GPT-5) in VS Code chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection status banner added with distinct visuals for "down" and "error".
  * Retry button lets users manually attempt reconnection.
  * App will automatically try alternate backend endpoints when the primary is unreachable.
  * Improved network handling for more reliable requests and clearer, timely error feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->