### PR TITLE
Fix API parameter inconsistency in hard difficulty quiz endpoints

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -404,9 +404,10 @@ def get_boolq_hard():
     )
 
     # Apply transformation to make each question harder
-    harder_questions = [make_question_harder(q) for q in generated]
+    for q in generated:
+        q["question"] = make_question_harder(q["question"])
 
-    return jsonify({"output": harder_questions})
+    return jsonify({"output": generated})
 
 @app.route('/upload', methods=['POST'])
 def upload_file():


### PR DESCRIPTION
## Description

This PR fixes an API parameter inconsistency in the backend quiz generation endpoints.

The hard difficulty endpoints:

- `/get_mcq_hard`
- `/get_shortq_hard`
- `/get_boolq_hard`

were previously expecting the parameter `input_question`, while the easy difficulty endpoints (`/get_mcq`, `/get_boolq`, `/get_shortq`) use `max_questions`.

Since the frontend sends `max_questions` for quiz generation requests, this mismatch could lead to incorrect behavior when generating hard difficulty quizzes.

This PR updates the hard difficulty endpoints to use the same `max_questions` parameter, ensuring consistent API behavior across all quiz generation endpoints.


---

### Addressed Issues:
Fixes #530


---

### Changes Made

- Updated `/get_mcq_hard` to use `max_questions` instead of `input_question`
- Updated `/get_shortq_hard` to use `max_questions` instead of `input_question`
- Updated `/get_boolq_hard` to use `max_questions` instead of `input_question`
- Ensured `num_questions` passed to `qg.generate()` correctly uses `max_questions`
- Maintained existing response format:  
  `return jsonify({"output": output})`
- No changes were made to easy difficulty endpoints.


---

### Screenshots/Recordings:
Not applicable (backend API fix).


---

### Additional Notes

This change improves backend API consistency and ensures proper communication between the frontend and backend during quiz generation.


---

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.


---

## AI Usage Disclosure

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools:

- Kiro AI assistant for code analysis and implementation guidance


---

### ⚠️ AI Notice - Important!

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined quiz endpoints to accept a numeric question count (default 4) via a shared request parser.
  * Hardened-question endpoints now modify each generated question in-place so hard variants return the same output shape with tougher wording.
  * Simplified internal request handling across multiple difficulty levels for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->