### PR TITLE
Fix: Standardize /generate_gform response shape for web and extension UIs

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -1,3 +1,5 @@
+from unittest import result
+
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from pprint import pprint
@@ -357,11 +359,13 @@ def generate_gform():
         formId=result["formId"], body=NEW_QUESTION
     ).execute()
 
-    edit_url = jsonify(result["responderUri"])
-    webbrowser.open_new_tab(
-        "https://docs.google.com/forms/d/" + result["formId"] + "/edit"
-    )
-    return edit_url
+    responder_url = result.get("responderUri")
+    edit_url = "https://docs.google.com/forms/d/" + result["formId"] + "/edit"
+
+    return jsonify({
+    "form_link": responder_url,
+    "edit_link": edit_url
+    }), 200
 
 
 @app.route("/get_shortq_hard", methods=["POST"])


### PR DESCRIPTION
This PR fixes the response shape mismatch in the /generate_gform endpoint.

Previously the backend returned a raw string containing responderUri, while the frontend expected a JSON object with form_link.

This change standardizes the API response to return:
{
  "form_link": responder_url,
  "edit_link": edit_url
}

This ensures both the web app and browser extension can correctly open the generated Google Form.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Form generation endpoint now returns both a shareable form link and an edit link in a single structured response.

* **Changes**
  * Automatic browser tab opening behavior has been removed from the form generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->