### PR TITLE
Fix Google Doc error message being treated as quiz input

### DIFF
--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -56,8 +56,14 @@ const Text_Input = () => {
       try {
         const data = await apiClient.post("/get_content", { document_url: docUrl });
         setDocUrl("");
-        setInputError("");
-        setText(data || "Error in retrieving");
+        
+        if (data) {
+          setInputError("");
+          setText(data);
+        } else {
+          setInputError("Error retrieving Google Doc content");
+        }
+      
       } catch (error) {
         console.error("Error:", error);
         setInputError("Error retrieving Google Doc content");

--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -9,6 +9,7 @@ import { Link,useNavigate } from "react-router-dom";
 import apiClient from "../utils/apiClient";
 
 const Text_Input = () => {
+  const [inputError, setInputError] = useState("");
   const navigate = useNavigate();
   const [text, setText] = useState("");
   const [difficulty, setDifficulty] = useState("Easy Difficulty");
@@ -55,10 +56,11 @@ const Text_Input = () => {
       try {
         const data = await apiClient.post("/get_content", { document_url: docUrl });
         setDocUrl("");
+        setInputError("");
         setText(data || "Error in retrieving");
       } catch (error) {
         console.error("Error:", error);
-        setText("Error retrieving Google Doc content");
+        setInputError("Error retrieving Google Doc content");
       } finally {
         setLoading(false);
       }
@@ -179,6 +181,10 @@ const Text_Input = () => {
           <style>{`textarea::-webkit-scrollbar { display: none; }`}</style>
         </div>
 
+        {inputError && (
+          <p className="mt-2 text-sm text-center text-red-300">{inputError}</p>
+        )}
+        
         {/* Separator */}
         <div className="text-white text-center my-4 text-lg">or</div>
 


### PR DESCRIPTION
###  Addressed Issues:

Fixes #575 

### Problem

When a user enters an invalid Google Doc URL, the API request fails and the error message "Error retrieving Google Doc content" is stored in the `text` state.

If the user clicks Next afterwards, this error message is treated as valid input and sent to the backend to generate a quiz.

### Fix

- Introduced a separate `inputError` state for handling errors.
- Prevented error messages from being stored in the `text` state.
- Displayed the error message below the textarea instead.

### Result

- Error messages are no longer treated as quiz input.
- Prevents invalid backend requests.
- Improves error handling and user experience.

###  Screen Recording


https://github.com/user-attachments/assets/ece66314-1614-41e7-b7f0-7b12580789ac




###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Displays a clear error message when document content cannot be retrieved, so users see immediate feedback.
  * Automatically clears the error message once content is successfully loaded, keeping the interface tidy.
  * Improves user-facing notifications during document loading to reduce confusion and better indicate success or failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->