### PR TITLE
fix(backend): standardize /get_mcq_answer output key

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -123,7 +123,7 @@ def get_mcq_answer():
     outputs = []
 
     if not input_questions or not input_options or len(input_questions) != len(input_options):
-        return jsonify({"outputs": outputs})
+        return jsonify({"output": outputs})
 
     for question, options in zip(input_questions, input_options):
         # Generate answer using the QA model


### PR DESCRIPTION
###  Addressed Issues:

Fixes #588


###  Screenshots/Recordings:

Not applicable (backend-only API consistency fix).


###  Additional Notes:
This PR fixes an inconsistent JSON response key in the MCQ answer endpoint.
Previously, one path returned `outputs` while the normal path returned `output`.
This PR standardizes the key to `output` in all cases so client handling stays consistent.
Scope is intentionally minimal: single-issue, single-file, low-risk fix.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: GPT-5.3-Codex via GitHub Copilot, local terminal validation.


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API response format inconsistency for the MCQ answer endpoint when handling invalid input, ensuring error responses now follow the same structure as successful responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->