### PR TITLE
fix: relax scipy version constraint for Windows Python 3.9 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ strsim==0.0.3
 six==1.16.0
 networkx==3.1
 numpy
-scipy>=1.11.0
+scipy>=1.11.0,<2.0.0
 scikit-learn==1.5.2
 unidecode==1.3
 future==0.18.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ strsim==0.0.3
 six==1.16.0
 networkx==3.1
 numpy
-scipy==1.14.1
+scipy>=1.11.0
 scikit-learn==1.5.2
 unidecode==1.3
 future==0.18.3


### PR DESCRIPTION
Fixes #382

## Problem
scipy==1.14.0 is not available for Python 3.9 on Windows,
blocking backend setup for contributors.

## Fix
Relaxed scipy version constraint from ==1.14.0 to >=1.11.0
allowing pip to install the best compatible version automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened SciPy dependency range to allow installation of any compatible 1.11.x–1.x release (up to, but not including, 2.0.0), improving compatibility across environments and easing upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->