### PR TITLE
fix: add Python version constraint for spaCy and warn against Python 3.12+ incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# WARNING: Python 3.9-3.11 required.
+# Python 3.12+ is not supported due to spaCy/blis incompatibility.
+
+
 torch==2.5.1
 transformers==4.46.1
 sense2vec==2.0.2
@@ -15,7 +19,7 @@ python-dateutil==2.8.2
 flashtext==2.7
 pandas
 sentencepiece==0.2.0
-spacy
+spacy>=3.7.2,<3.8.0; python_version<"3.12"
 flask
 flask_cors
 nltk

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,8 +28,7 @@ google-api-python-client==2.113.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 oauth2client==4.1.3
-en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl#sha256=86cc141f63942d4b2c5fcee06630fd6f904788d2f0ab005cce45aadb8fb73889
-google-auth 
+en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl#sha256=86cc141f63942d4b2c5fcee06630fd6f904788d2f0ab005cce45aadb8fb73889 ; python_version<"3.12"
 datasets==3.1.0
 tokenizers
 mammoth


### PR DESCRIPTION
Fixes #370

## Problem
Installation fails on Python 3.12+ due to spaCy/blis 
incompatibility. Users were getting cryptic errors with 
no clear explanation.

## Fix
- Added Python version marker to spaCy dependency 
  (spacy>=3.7.2,<3.8.0; python_version<"3.12")
- Added clear warning comment at top of requirements.txt 
  stating Python 3.9-3.11 is required
- This gives users a clear signal before attempting 
  installation on unsupported Python versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python version support to require Python 3.9–3.11; Python 3.12+ is no longer supported due to dependency incompatibilities.
  * Pinned spaCy dependency to a specific compatible version for supported Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->