### PR TITLE
feat(backend): add /api/diagnostics endpoint for environment and dependency health

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -499,6 +499,11 @@ def system_diagnostics():
     Requires zero external dependencies. Assists maintainers in debugging
     contributor setup failures (e.g., missing PyTorch wheels on Windows).
     """
+    # Security: Ensure this endpoint is not publicly exposed in production
+    # Maintainers/students can set ENABLE_DIAGNOSTICS=true in their local .env
+    if os.getenv("ENABLE_DIAGNOSTICS", "false").lower() != "true":
+        return jsonify({"error": "Diagnostics disabled. Set ENABLE_DIAGNOSTICS=true in environment to access."}), 403
+
     diagnostics = {
         "status": "healthy",
         "system": {
@@ -511,18 +516,23 @@ def system_diagnostics():
         "ml_environment": {
             "pytorch_available": False,
             "cuda_available": False,
-            "torch_version": None
+            "torch_version": None,
+            "error_log": None
         }
     }
 
-    # Safely check PyTorch status without hard crashing if missing
+    # Safely check PyTorch status catching all underlying C++ / OS level crashes
     try:
         import torch
         diagnostics["ml_environment"]["pytorch_available"] = True
         diagnostics["ml_environment"]["torch_version"] = torch.__version__
         diagnostics["ml_environment"]["cuda_available"] = torch.cuda.is_available()
-    except ImportError:
+    except ModuleNotFoundError:
         diagnostics["status"] = "degraded (pytorch missing)"
+        diagnostics["ml_environment"]["error_log"] = "ModuleNotFoundError"
+    except Exception as e:
+        diagnostics["status"] = "degraded (pytorch broken install)"
+        diagnostics["ml_environment"]["error_log"] = str(e)
 
     return jsonify(diagnostics), 200
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,3 +1,5 @@
+import platform
+import sys
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from pprint import pprint
@@ -489,6 +491,40 @@ def get_transcript():
     os.remove(latest_subtitle)
 
     return jsonify({"transcript": transcript_text})
+
+@app.route('/api/diagnostics', methods=['GET'])
+def system_diagnostics():
+    """
+    Lightweight endpoint to diagnose local environment bottlenecks.
+    Requires zero external dependencies. Assists maintainers in debugging
+    contributor setup failures (e.g., missing PyTorch wheels on Windows).
+    """
+    diagnostics = {
+        "status": "healthy",
+        "system": {
+            "os": platform.system(),
+            "release": platform.release(),
+            "architecture": platform.machine(),
+            "python_version": sys.version.split(' ')[0],
+            "cpu_count": os.cpu_count()
+        },
+        "ml_environment": {
+            "pytorch_available": False,
+            "cuda_available": False,
+            "torch_version": None
+        }
+    }
+
+    # Safely check PyTorch status without hard crashing if missing
+    try:
+        import torch
+        diagnostics["ml_environment"]["pytorch_available"] = True
+        diagnostics["ml_environment"]["torch_version"] = torch.__version__
+        diagnostics["ml_environment"]["cuda_available"] = torch.cuda.is_available()
+    except ImportError:
+        diagnostics["status"] = "degraded (pytorch missing)"
+
+    return jsonify(diagnostics), 200
 
 if __name__ == "__main__":
     os.makedirs("subtitles", exist_ok=True)


### PR DESCRIPTION
### Addressed Issues:
Fixes N/A (Proactive backend infrastructure addition to assist maintainers in triaging local setup and dependency failures).

### Screenshots/Recordings:
N/A (Backend JSON Endpoint).

**Expected Output from `GET /api/diagnostics`:**
```json
{
  "status": "healthy",
  "system": {
    "os": "Windows",
    "release": "10",
    "architecture": "AMD64",
    "python_version": "3.10.11",
    "cpu_count": 8
  },
  "ml_environment": {
    "pytorch_available": true,
    "cuda_available": false,
    "torch_version": "2.1.2+cpu"
  }
}
```

###  Additional Notes:
<!-- Add any additional information, context, or notes for reviewers -->
This PR introduces a lightweight /api/diagnostics endpoint to backend/server.py.

Currently, when new contributors (especially those on Windows or machines with 8GB RAM) experience backend crashes during onboarding, maintainers have to guess if the issue is a Python version mismatch, a missing PyTorch wheel, or a CPU/VRAM bottleneck.

This endpoint requires zero new dependencies and provides an instant snapshot of the host's environment. Moving forward, when a user reports a crash in the Discord, maintainers can simply ask them to ping /api/diagnostics and share the output, drastically reducing triage time and friction for GSoC applicants.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: TODO


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics endpoint that returns OS, release, architecture, Python version, CPU count, and ML framework availability.
  * Reports ML runtime status (available/unavailable), framework version, CUDA availability, and any detection errors.
  * When diagnostics are disabled, the endpoint responds with a 403 access denied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->