### PR TITLE
Improve difficulty selector UI for better clarity

### DIFF
--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -216,7 +216,12 @@ const Text_Input = () => {
 
           {/* Difficulty Selector */}
           <div className="flex items-center gap-2">
-            <span className="text-white text-lg sm:text-xl font-bold">Difficulty:</span>
+            <label
+              htmlFor="difficulty"
+              className="text-white text-lg sm:text-xl font-bold"
+            >
+              Difficulty:
+            </label>
 
             <select
               id="difficulty"

--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -5,13 +5,13 @@ import stars from "../assets/stars.png";
 import cloud from "../assets/cloud.png";
 import { FaClipboard } from "react-icons/fa";
 import Switch from "react-switch";
-import { Link,useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import apiClient from "../utils/apiClient";
 
 const Text_Input = () => {
   const navigate = useNavigate();
   const [text, setText] = useState("");
-  const [difficulty, setDifficulty] = useState("Easy Difficulty");
+  const [difficulty, setDifficulty] = useState("easy");
   const [numQuestions, setNumQuestions] = useState(10);
   const [loading, setLoading] = useState(false);
   const fileInputRef = useRef(null);
@@ -89,7 +89,7 @@ const Text_Input = () => {
   };
 
   const getEndpoint = (difficulty, questionType) => {
-    if (difficulty !== "Easy Difficulty") {
+    if (difficulty !== "easy") {
       if (questionType === "get_shortq") {
         return "get_shortq_hard";
       } else if (questionType === "get_mcq") {
@@ -214,15 +214,18 @@ const Text_Input = () => {
             <button onClick={incrementQuestions} className="rounded-lg border-2 border-[#6e8a9f] text-white text-xl px-3">+</button>
           </div>
 
-          {/* Difficulty Dropdown */}
-          <div className="text-center">
+          {/* Difficulty Selector */}
+          <div className="flex items-center gap-2">
+            <span className="text-white text-lg sm:text-xl font-bold">Difficulty:</span>
+
             <select
+              id="difficulty"
               value={difficulty}
               onChange={handleDifficultyChange}
               className="bg-[#3e5063] text-white text-lg rounded-xl p-2 outline-none"
             >
-              <option value="Easy Difficulty">Easy Difficulty</option>
-              <option value="Hard Difficulty">Hard Difficulty</option>
+              <option value="easy">Easy</option>
+              <option value="hard">Hard</option>
             </select>
           </div>
 


### PR DESCRIPTION
### Summary
Improved the difficulty selector UI by separating the label from the dropdown and simplifying the options.

### Changes
- Added label "Difficulty"
- Updated dropdown options to "Easy" and "Hard"
- Simplified internal difficulty handling (easy/hard)

### Why
The previous UI mixed label and value ("Easy Difficulty"), which reduced clarity.
This change improves readability and aligns with standard UI patterns.

Closes #630

Screenshots attached for ref:

Before:
<img width="2410" height="1378" alt="before" src="https://github.com/user-attachments/assets/74959e41-ab9f-4398-96ef-e21253656c00" />


After:
<img width="2557" height="1466" alt="after" src="https://github.com/user-attachments/assets/6ff86fe8-7543-443b-9327-1495bc548371" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized difficulty selection to use canonical values ("easy" / "hard") and set the default to "easy".
  * Updated the difficulty selector UI with clear labels for improved clarity.
  * Ensures correct behavior when choosing the non-easy difficulty so the harder option reliably takes effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->