### PR TITLE
fix: add timeout protection to ML model endpoints

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -5,6 +5,8 @@ import nltk
 import subprocess
 import os
 import glob
+import signal
+from functools import wraps
 
 from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -46,6 +48,43 @@ qa_model = pipeline("question-answering")
 llm_generator = LLMQuestionGenerator()
 
 
+ML_TIMEOUT_SECONDS = 120
+
+
+class MLTimeoutError(Exception):
+    """Raised when an ML operation exceeds the timeout."""
+    pass
+
+
+def with_timeout(timeout_seconds=ML_TIMEOUT_SECONDS):
+    """Decorator that adds timeout protection to ML endpoint functions.
+
+    Returns HTTP 504 if the operation exceeds the timeout.
+    On Windows, uses a simple try/except wrapper (signal.alarm not available).
+    """
+    def decorator(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            if hasattr(signal, 'SIGALRM'):
+                def handler(signum, frame):
+                    raise MLTimeoutError(
+                        f"Operation timed out after {timeout_seconds} seconds"
+                    )
+                old_handler = signal.signal(signal.SIGALRM, handler)
+                signal.alarm(timeout_seconds)
+                try:
+                    result = f(*args, **kwargs)
+                finally:
+                    signal.alarm(0)
+                    signal.signal(signal.SIGALRM, old_handler)
+                return result
+            else:
+                # Windows fallback: no signal-based timeout, just run normally
+                return f(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
 def process_input_text(input_text, use_mediawiki):
     if use_mediawiki == 1:
         input_text = mediawikiapi.summary(input_text,8)
@@ -53,31 +92,47 @@ def process_input_text(input_text, use_mediawiki):
 
 
 @app.route("/get_mcq", methods=["POST"])
+@with_timeout()
 def get_mcq():
     data = request.get_json()
+    if not data or not data.get("input_text"):
+        return jsonify({"error": "input_text is required"}), 400
     input_text = data.get("input_text", "")
     use_mediawiki = data.get("use_mediawiki", 0)
     max_questions = data.get("max_questions", 4)
-    input_text = process_input_text(input_text, use_mediawiki)
-    output = MCQGen.generate_mcq(
-        {"input_text": input_text, "max_questions": max_questions}
-    )
-    questions = output["questions"]
-    return jsonify({"output": questions})
+    try:
+        input_text = process_input_text(input_text, use_mediawiki)
+        output = MCQGen.generate_mcq(
+            {"input_text": input_text, "max_questions": max_questions}
+        )
+        questions = output["questions"]
+        return jsonify({"output": questions})
+    except MLTimeoutError:
+        return jsonify({"error": "Request timed out. The model took too long to respond."}), 504
+    except Exception as e:
+        return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
 
 @app.route("/get_boolq", methods=["POST"])
+@with_timeout()
 def get_boolq():
     data = request.get_json()
+    if not data or not data.get("input_text"):
+        return jsonify({"error": "input_text is required"}), 400
     input_text = data.get("input_text", "")
     use_mediawiki = data.get("use_mediawiki", 0)
     max_questions = data.get("max_questions", 4)
-    input_text = process_input_text(input_text, use_mediawiki)
-    output = BoolQGen.generate_boolq(
-        {"input_text": input_text, "max_questions": max_questions}
-    )
-    boolean_questions = output["Boolean_Questions"]
-    return jsonify({"output": boolean_questions})
+    try:
+        input_text = process_input_text(input_text, use_mediawiki)
+        output = BoolQGen.generate_boolq(
+            {"input_text": input_text, "max_questions": max_questions}
+        )
+        boolean_questions = output["Boolean_Questions"]
+        return jsonify({"output": boolean_questions})
+    except MLTimeoutError:
+        return jsonify({"error": "Request timed out. The model took too long to respond."}), 504
+    except Exception as e:
+        return jsonify({"error": f"An error occurred: {str(e)}"}), 500
 
 
 @app.route("/get_shortq", methods=["POST"])

--- a/backend/server.py
+++ b/backend/server.py
@@ -6,6 +6,7 @@ import subprocess
 import os
 import glob
 import signal
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from functools import wraps
 
 from sklearn.metrics.pairwise import cosine_similarity
@@ -79,8 +80,15 @@ def with_timeout(timeout_seconds=ML_TIMEOUT_SECONDS):
                     signal.signal(signal.SIGALRM, old_handler)
                 return result
             else:
-                # Windows fallback: no signal-based timeout, just run normally
-                return f(*args, **kwargs)
+                # Windows fallback: use ThreadPoolExecutor for timeout
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    future = executor.submit(f, *args, **kwargs)
+                    try:
+                        return future.result(timeout=timeout_seconds)
+                    except FuturesTimeoutError:
+                        raise MLTimeoutError(
+                            f"Operation timed out after {timeout_seconds} seconds"
+                        )
         return wrapper
     return decorator
 
@@ -109,8 +117,8 @@ def get_mcq():
         return jsonify({"output": questions})
     except MLTimeoutError:
         return jsonify({"error": "Request timed out. The model took too long to respond."}), 504
-    except Exception as e:
-        return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+    except Exception:
+        return jsonify({"error": "An internal server error occurred."}), 500
 
 
 @app.route("/get_boolq", methods=["POST"])
@@ -131,22 +139,30 @@ def get_boolq():
         return jsonify({"output": boolean_questions})
     except MLTimeoutError:
         return jsonify({"error": "Request timed out. The model took too long to respond."}), 504
-    except Exception as e:
-        return jsonify({"error": f"An error occurred: {str(e)}"}), 500
+    except Exception:
+        return jsonify({"error": "An internal server error occurred."}), 500
 
 
 @app.route("/get_shortq", methods=["POST"])
+@with_timeout()
 def get_shortq():
     data = request.get_json()
+    if not data or not data.get("input_text"):
+        return jsonify({"error": "input_text is required"}), 400
     input_text = data.get("input_text", "")
     use_mediawiki = data.get("use_mediawiki", 0)
     max_questions = data.get("max_questions", 4)
-    input_text = process_input_text(input_text, use_mediawiki)
-    output = ShortQGen.generate_shortq(
-        {"input_text": input_text, "max_questions": max_questions}
-    )
-    questions = output["questions"]
-    return jsonify({"output": questions})
+    try:
+        input_text = process_input_text(input_text, use_mediawiki)
+        output = ShortQGen.generate_shortq(
+            {"input_text": input_text, "max_questions": max_questions}
+        )
+        questions = output["questions"]
+        return jsonify({"output": questions})
+    except MLTimeoutError:
+        return jsonify({"error": "Request timed out. The model took too long to respond."}), 504
+    except Exception:
+        return jsonify({"error": "An internal server error occurred."}), 500
 
 
 @app.route("/get_shortq_llm", methods=["POST"])


### PR DESCRIPTION
## Summary
Add timeout protection and input validation to ML model endpoints to prevent indefinite hangs.

## Changes
- Add `with_timeout()` decorator using `signal.SIGALRM` (Unix) with Windows fallback
- Add `MLTimeoutError` exception for clean timeout handling
- Apply to `get_mcq` and `get_boolq` endpoints (pattern for other endpoints)
- Add input validation — returns 400 for missing `input_text`
- Return proper HTTP 504 on timeout, 500 on internal errors

## Test plan
- [ ] Send valid request → normal response
- [ ] Send request without `input_text` → 400 error
- [ ] Slow model response → 504 timeout after 120s
- [ ] Other endpoints still work without timeout (decorator can be added incrementally)

Closes #592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeout protection for ML-heavy question-generation API endpoints to prevent long-running requests.

* **Bug Fixes**
  * Enforced input validation for question-generation endpoints (missing input now returns 400).
  * Improved error responses: timeouts return 504; other processing failures return 500, with clearer failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->