### PR TITLE
fix: update scipy version for Python 3.9 Windows compatibility (#382)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ strsim==0.0.3
 six==1.16.0
 networkx==3.1
 numpy
-scipy==1.14.1
+scipy>=1.11.0
 scikit-learn==1.5.2
 unidecode==1.3
 future==0.18.3


### PR DESCRIPTION
```
Fixes #382

## Problem
scipy==1.14.0 is not available for Python 3.9 on Windows,
which causes backend dependency installation to fail.

## Fix
Updated scipy version constraint from scipy==1.14.0 
to scipy>=1.11.0 to ensure compatibility with 
Python 3.9 on Windows systems.

## Testing
Verified requirements.txt installs correctly on 
Windows with Python 3.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SciPy dependency constraint to accept compatible versions 1.11.0 and above, replacing the previously fixed version requirement with a minimum-version range for improved flexibility in environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->