### PR TITLE
fix(web): prevent Previous page crash on malformed localStorage JSON

### DIFF
--- a/eduaid_web/src/pages/Previous.jsx
+++ b/eduaid_web/src/pages/Previous.jsx
@@ -11,7 +11,22 @@ const Previous = () => {
 
   const getQuizzesFromLocalStorage = () => {
     const quizzes = localStorage.getItem("last5Quizzes");
-    return quizzes ? JSON.parse(quizzes) : [];
+    if (!quizzes) {
+      return [];
+    }
+
+    try {
+      const parsedQuizzes = JSON.parse(quizzes);
+      if (!Array.isArray(parsedQuizzes)) {
+        localStorage.removeItem("last5Quizzes");
+        return [];
+      }
+
+      return parsedQuizzes;
+    } catch (error) {
+      localStorage.removeItem("last5Quizzes");
+      return [];
+    }
   };
 
   const [quizzes, setQuizzes] = React.useState(getQuizzesFromLocalStorage());


### PR DESCRIPTION
## Summary
- guard last5Quizzes parsing in Previous.jsx with 	ry/catch
- validate parsed payload is an array before using it
- clear corrupted localStorage value and fall back to an empty quiz list

## Why
The Previous page currently assumes last5Quizzes is always valid JSON. If the key is malformed, JSON.parse throws and the page crashes.

Fixes #643

## Validation
- 
pm --prefix eduaid_web run build (successful; existing unrelated lint warnings remain in the project)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of corrupted quiz history data to prevent app crashes. The app now gracefully recovers when local storage contains invalid or malformed data, automatically clearing problematic entries and restoring functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->