### PR TITLE
Add direct numeric input for "Number of Questions" (Enhancement #647)

### DIFF
--- a/eduaid_web/src/index.css
+++ b/eduaid_web/src/index.css
@@ -23,3 +23,13 @@ code {
   border-image-slice: 1;
   border-radius: 2rem;
 }
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none !important;
+  margin: 0;
+}
+
+input[type="number"] {
+  -moz-appearance: textfield !important;
+}

--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -66,7 +66,10 @@ const Text_Input = () => {
       // Proceed with existing functionality for local storage
       localStorage.setItem("textContent", text);
       localStorage.setItem("difficulty", difficulty);
-      localStorage.setItem("numQuestions", numQuestions);
+      localStorage.setItem(
+        "numQuestions",
+        parseInt(numQuestions, 10) >= 1 ? parseInt(numQuestions, 10) : 1
+      );
 
       await sendToBackend(
         text,
@@ -104,7 +107,7 @@ const Text_Input = () => {
     try {
       const requestData = {
         input_text: data,
-        max_questions: numQuestions,
+        max_questions: parseInt(numQuestions, 10) >= 1 ? parseInt(numQuestions, 10) : 1,
         use_mediawiki: isToggleOn,
       };
 

--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -210,7 +210,30 @@ const Text_Input = () => {
           <div className="flex gap-2 items-center">
             <div className="text-white text-lg sm:text-xl font-bold">No. of Questions:</div>
             <button onClick={decrementQuestions} className="rounded-lg border-2 border-[#6e8a9f] text-white text-xl px-3">-</button>
-            <span className="text-white text-2xl">{numQuestions}</span>
+            <input
+              type="number"
+              value={numQuestions}
+              min={1}
+              onChange={(e) => {
+                const value = e.target.value;
+
+                if (value === "") {
+                  setNumQuestions("");
+                  return;
+                }
+
+                const parsed = Number(value);
+                if (!isNaN(parsed) && parsed >= 1) {
+                  setNumQuestions(parsed);
+                }
+              }}
+              onBlur={() => {
+                if (!numQuestions || numQuestions < 1) {
+                  setNumQuestions(1);
+                }
+              }}
+              className="w-16 text-center bg-transparent border-2 border-[#6e8a9f] text-white text-lg rounded-lg outline-none"
+            />
             <button onClick={incrementQuestions} className="rounded-lg border-2 border-[#6e8a9f] text-white text-xl px-3">+</button>
           </div>
 


### PR DESCRIPTION
Fixes #647 

Summary

This PR enhances the "Number of Questions" input by allowing users to directly enter a numeric value instead of relying solely on increment/decrement buttons.

Changes Made
Added <input type="number"> alongside existing +/- controls
Implemented validation (minimum value = 1)
Handled edge cases (empty input, invalid values)
Removed default browser spinner UI for consistency
Preserved existing functionality (backward compatible)

Problem
Previously, users had to click the "+" button repeatedly to reach larger values, leading to poor UX.

Solution

Introduced a hybrid input system:
Direct typing for efficiency
Buttons for quick adjustments

Before:

<img width="2559" height="1380" alt="Screenshot 2026-03-29 211321" src="https://github.com/user-attachments/assets/7db4c716-83dd-4da8-931a-717a739e2b13" />


After:

<img width="2551" height="1381" alt="Screenshot 2026-03-29 232541" src="https://github.com/user-attachments/assets/98109512-28e3-492a-bd9d-183a04624fc4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Number field is now directly editable, accepts temporary empty input, and enforces a minimum value on blur; sanitized integer values are preserved and sent with requests.

* **Style**
  * Improved number-input styling for consistent, cleaner appearance across browsers and removed native spinner controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->