### PR TITLE
add full quiz histrory with show more/show less functionality

### DIFF
--- a/eduaid_web/src/pages/Previous.jsx
+++ b/eduaid_web/src/pages/Previous.jsx
@@ -10,11 +10,14 @@ const Previous = () => {
   const navigate = useNavigate();
 
   const getQuizzesFromLocalStorage = () => {
-    const quizzes = localStorage.getItem("last5Quizzes");
+    const quizzes = localStorage.getItem("allQuizzes");
     return quizzes ? JSON.parse(quizzes) : [];
   };
 
   const [quizzes, setQuizzes] = React.useState(getQuizzesFromLocalStorage());
+
+  const [showAll, setShowAll] = React.useState(false);
+  const displayedQuizzes = showAll ? quizzes : quizzes.slice(0, 5);
 
   const handleQuizClick = (quiz) => {
     localStorage.setItem("qaPairs", JSON.stringify(quiz.qaPair));
@@ -22,7 +25,7 @@ const Previous = () => {
   };
 
   const handleClearQuizzes = () => {
-    localStorage.removeItem("last5Quizzes");
+    localStorage.removeItem("allQuizzes");
     setQuizzes([]);
   };
 
@@ -71,7 +74,7 @@ const Previous = () => {
             <div className="text-center text-white text-sm">No quizzes available</div>
           ) : (
             <ul className="space-y-2">
-              {quizzes.map((quiz, index) => (
+              {displayedQuizzes.map((quiz, index) => (
                 <li
                   key={index}
                   className="bg-[#202838] p-4 rounded-lg text-white cursor-pointer border-dotted border-2 border-[#7600F2] flex justify-between items-center"
@@ -89,6 +92,28 @@ const Previous = () => {
             </ul>
           )}
         </div>
+
+        {quizzes.length > 5 && !showAll && (
+          <div className="flex justify-center mt-3">
+            <button
+              onClick={() => setShowAll(true)}
+              className="bg-black text-white px-5 py-2 text-sm md:text-base border-gradient"
+            >
+              Show More
+            </button>
+          </div>
+        )}
+
+        {showAll && (
+          <div className="flex justify-center mt-3">
+            <button
+              onClick={() => setShowAll(false)}
+              className="bg-black text-white px-5 py-2 text-sm md:text-base border-gradient"
+            >
+              Show Less
+            </button>
+          </div>
+        )}
 
         {/* Buttons */}
         <div className="flex flex-wrap justify-center gap-4">

--- a/eduaid_web/src/pages/Previous.jsx
+++ b/eduaid_web/src/pages/Previous.jsx
@@ -27,6 +27,7 @@ const Previous = () => {
   const handleClearQuizzes = () => {
     localStorage.removeItem("allQuizzes");
     setQuizzes([]);
+    setShowAll(false);
   };
 
   const handleBack = () => {

--- a/eduaid_web/src/pages/Text_Input.jsx
+++ b/eduaid_web/src/pages/Text_Input.jsx
@@ -119,13 +119,12 @@ const Text_Input = () => {
         qaPair: responseData,
       };
 
-      let last5Quizzes =
-        JSON.parse(localStorage.getItem("last5Quizzes")) || [];
-      last5Quizzes.push(quizDetails);
-      if (last5Quizzes.length > 5) {
-        last5Quizzes.shift(); // Keep only the last 5 quizzes
-      }
-      localStorage.setItem("last5Quizzes", JSON.stringify(last5Quizzes));
+      const allQuizzes =
+        JSON.parse(localStorage.getItem("allQuizzes")) || [];
+
+      const updatedQuizzes = [quizDetails, ...allQuizzes];
+
+      localStorage.setItem("allQuizzes", JSON.stringify(updatedQuizzes));
 
       navigate("/output");
     } catch (error) {


### PR DESCRIPTION
### Addressed Issues:
Fixes https://github.com/AOSSIE-Org/EduAid/issues/641

Improves the quiz dashboard history to display all generated quizzes instead of only last 5 and adds a show more/show less option to view full history.

### How It Solves the Issue:
- Replaced the limited storage approach with allQuizzes to persist all generated quizzes in localStorage.
- Added a "Show More / Show Less" toggle in the Quiz Dashboard:
- Displays only the latest 5 quizzes initially for a clean UI
- Allows users to expand and view the complete quiz history when needed

This ensures no quiz data is lost while maintaining a user-friendly interface.

### Screenshots/Recordings:

Before :

https://github.com/user-attachments/assets/af3f7a61-f9e5-411b-8001-9cc2300c49c4

After :

https://github.com/user-attachments/assets/01a87e01-7de8-4977-bee2-eb68fda10050



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quiz history now stores and displays all previous quizzes instead of limiting to the last 5.
  * Added "Show More" and "Show Less" buttons to toggle between the first 5 items and the complete history (Show More appears only when >5).
  * Quiz history persists across sessions for better tracking of past work.
  * Clear action removes the entire quiz history and resets the view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->