### PR TITLE
introduce deterministic mode for reproducible LLM-based question generation

### DIFF
--- a/backend/Generator/llm_generator.py
+++ b/backend/Generator/llm_generator.py
@@ -39,9 +39,17 @@ class LLMQuestionGenerator:
             input_text = " ".join(words[:max_words])
         return input_text
 
-    def generate_short_questions(self, input_text, max_questions=4):
+    def generate_short_questions(self, input_text, max_questions=4, deterministic=False):
         """Generate short-answer questions from the given text."""
+        # Input validation
+        if not input_text or not isinstance(input_text, str):
+            return []
+        
         self._load_model()
+        
+        # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
+        seed_value = hash(input_text) % (2**32) if deterministic else None
+        
         input_text = self._prepare_text(input_text)
 
         prompt = (
@@ -51,6 +59,16 @@ class LLMQuestionGenerator:
             f'Format: [{{"question": "...", "answer": "..."}}]\n'
             f"/no_think"
         )
+
+        params = {
+            "max_tokens": 512,
+            "temperature": 0.7,
+        }
+
+        if deterministic:
+            params["temperature"] = 0.0
+            params["top_p"] = 1.0
+            params["seed"] = seed_value
 
         response = self.llm.create_chat_completion(
             messages=[
@@ -63,8 +81,7 @@ class LLMQuestionGenerator:
                     "content": prompt,
                 },
             ],
-            max_tokens=512,
-            temperature=0.7,
+            **params
         )
 
         try:
@@ -78,9 +95,17 @@ class LLMQuestionGenerator:
         except (AttributeError, TypeError, ValueError):
             return []
 
-    def generate_mcq_questions(self, input_text, max_questions=4):
+    def generate_mcq_questions(self, input_text, max_questions=4, deterministic=False):
         """Generate multiple-choice questions from the given text."""
+        # Input validation
+        if not input_text or not isinstance(input_text, str):
+            return []
+        
         self._load_model()
+        
+        # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
+        seed_value = hash(input_text) % (2**32) if deterministic else None
+        
         input_text = self._prepare_text(input_text)
 
         prompt = (
@@ -91,6 +116,16 @@ class LLMQuestionGenerator:
             f'Format: [{{"question": "...", "options": ["A) ...", "B) ...", "C) ...", "D) ..."], "correct_answer": "A"}}]\n'
             f"/no_think"
         )
+
+        params = {
+            "max_tokens": 1024,
+            "temperature": 0.7,
+        }
+
+        if deterministic:
+            params["temperature"] = 0.0
+            params["top_p"] = 1.0
+            params["seed"] = seed_value
 
         response = self.llm.create_chat_completion(
             messages=[
@@ -103,8 +138,7 @@ class LLMQuestionGenerator:
                     "content": prompt,
                 },
             ],
-            max_tokens=1024,
-            temperature=0.7,
+            **params
         )
 
         try:
@@ -118,9 +152,17 @@ class LLMQuestionGenerator:
         except (AttributeError, TypeError, ValueError):
             return []
 
-    def generate_boolean_questions(self, input_text, max_questions=4):
+    def generate_boolean_questions(self, input_text, max_questions=4, deterministic=False):
         """Generate true/false questions from the given text."""
+        # Input validation
+        if not input_text or not isinstance(input_text, str):
+            return []
+        
         self._load_model()
+        
+        # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
+        seed_value = hash(input_text) % (2**32) if deterministic else None
+        
         input_text = self._prepare_text(input_text)
 
         prompt = (
@@ -130,6 +172,16 @@ class LLMQuestionGenerator:
             f'Format: [{{"question": "...", "answer": true/false}}]\n'
             f"/no_think"
         )
+
+        params = {
+            "max_tokens": 512,
+            "temperature": 0.7,
+        }
+
+        if deterministic:
+            params["temperature"] = 0.0
+            params["top_p"] = 1.0
+            params["seed"] = seed_value
 
         response = self.llm.create_chat_completion(
             messages=[
@@ -142,8 +194,7 @@ class LLMQuestionGenerator:
                     "content": prompt,
                 },
             ],
-            max_tokens=512,
-            temperature=0.7,
+            **params
         )
 
         try:
@@ -157,12 +208,12 @@ class LLMQuestionGenerator:
         except (AttributeError, TypeError, ValueError):
             return []
 
-    def generate_all_questions(self, input_text, mcq_count=2, bool_count=2, short_count=2):
+    def generate_all_questions(self, input_text, mcq_count=2, bool_count=2, short_count=2, deterministic=False):
         """Generate a mix of all question types."""
         questions = []
 
         # Generate MCQs
-        mcqs = self.generate_mcq_questions(input_text, mcq_count)
+        mcqs = self.generate_mcq_questions(input_text, mcq_count, deterministic)
         for mcq in mcqs:
             questions.append({
                 "type": "mcq",
@@ -172,7 +223,7 @@ class LLMQuestionGenerator:
             })
 
         # Generate Boolean questions
-        bool_qs = self.generate_boolean_questions(input_text, bool_count)
+        bool_qs = self.generate_boolean_questions(input_text, bool_count, deterministic)
         for bool_q in bool_qs:
             questions.append({
                 "type": "boolean",
@@ -181,7 +232,7 @@ class LLMQuestionGenerator:
             })
 
         # Generate Short questions
-        short_qs = self.generate_short_questions(input_text, short_count)
+        short_qs = self.generate_short_questions(input_text, short_count, deterministic)
         for short_q in short_qs:
             questions.append({
                 "type": "short_answer",

--- a/backend/Generator/llm_generator.py
+++ b/backend/Generator/llm_generator.py
@@ -1,6 +1,7 @@
 import json
 import re
 import threading
+import hashlib
 from llama_cpp import Llama
 
 
@@ -48,7 +49,7 @@ class LLMQuestionGenerator:
         self._load_model()
         
         # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
-        seed_value = hash(input_text) % (2**32) if deterministic else None
+        seed_value = int(hashlib.sha256(input_text.encode()).hexdigest()[:8], 16) if deterministic else None
         
         input_text = self._prepare_text(input_text)
 
@@ -104,7 +105,7 @@ class LLMQuestionGenerator:
         self._load_model()
         
         # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
-        seed_value = hash(input_text) % (2**32) if deterministic else None
+        seed_value = int(hashlib.sha256(input_text.encode()).hexdigest()[:8], 16) if deterministic else None
         
         input_text = self._prepare_text(input_text)
 
@@ -161,7 +162,7 @@ class LLMQuestionGenerator:
         self._load_model()
         
         # Compute seed BEFORE text truncation to ensure different inputs produce different seeds
-        seed_value = hash(input_text) % (2**32) if deterministic else None
+        seed_value = int(hashlib.sha256(input_text.encode()).hexdigest()[:8], 16) if deterministic else None
         
         input_text = self._prepare_text(input_text)
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -102,6 +102,10 @@ def get_shortq_llm():
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
         deterministic = data.get("deterministic", False)
+        
+        if not isinstance(deterministic, bool):
+            return jsonify({"error": "deterministic must be a boolean"}), 400
+        
         input_text = process_input_text(input_text, use_mediawiki)
         questions = llm_generator.generate_short_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
@@ -118,6 +122,10 @@ def get_mcq_llm():
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
         deterministic = data.get("deterministic", False)
+        
+        if not isinstance(deterministic, bool):
+            return jsonify({"error": "deterministic must be a boolean"}), 400
+        
         input_text = process_input_text(input_text, use_mediawiki)
         questions = llm_generator.generate_mcq_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
@@ -134,6 +142,10 @@ def get_boolq_llm():
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
         deterministic = data.get("deterministic", False)
+        
+        if not isinstance(deterministic, bool):
+            return jsonify({"error": "deterministic must be a boolean"}), 400
+        
         input_text = process_input_text(input_text, use_mediawiki)
         questions = llm_generator.generate_boolean_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
@@ -152,6 +164,10 @@ def get_problems_llm():
         bool_count = data.get("max_questions_boolq", 2)
         short_count = data.get("max_questions_shortq", 2)
         deterministic = data.get("deterministic", False)
+        
+        if not isinstance(deterministic, bool):
+            return jsonify({"error": "deterministic must be a boolean"}), 400
+        
         input_text = process_input_text(input_text, use_mediawiki)
         questions = llm_generator.generate_all_questions(input_text, mcq_count, bool_count, short_count, deterministic)
         return jsonify({"output": questions})

--- a/backend/server.py
+++ b/backend/server.py
@@ -101,8 +101,9 @@ def get_shortq_llm():
         input_text = data.get("input_text", "")
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
+        deterministic = data.get("deterministic", False)
         input_text = process_input_text(input_text, use_mediawiki)
-        questions = llm_generator.generate_short_questions(input_text, max_questions)
+        questions = llm_generator.generate_short_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
     except Exception as e:
         app.logger.exception("Error in /get_shortq_llm: %s", e)
@@ -116,8 +117,9 @@ def get_mcq_llm():
         input_text = data.get("input_text", "")
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
+        deterministic = data.get("deterministic", False)
         input_text = process_input_text(input_text, use_mediawiki)
-        questions = llm_generator.generate_mcq_questions(input_text, max_questions)
+        questions = llm_generator.generate_mcq_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
     except Exception as e:
         app.logger.exception("Error in /get_mcq_llm: %s", e)
@@ -131,8 +133,9 @@ def get_boolq_llm():
         input_text = data.get("input_text", "")
         use_mediawiki = data.get("use_mediawiki", 0)
         max_questions = data.get("max_questions", 4)
+        deterministic = data.get("deterministic", False)
         input_text = process_input_text(input_text, use_mediawiki)
-        questions = llm_generator.generate_boolean_questions(input_text, max_questions)
+        questions = llm_generator.generate_boolean_questions(input_text, max_questions, deterministic)
         return jsonify({"output": questions})
     except Exception as e:
         app.logger.exception("Error in /get_boolq_llm: %s", e)
@@ -148,8 +151,9 @@ def get_problems_llm():
         mcq_count = data.get("max_questions_mcq", 2)
         bool_count = data.get("max_questions_boolq", 2)
         short_count = data.get("max_questions_shortq", 2)
+        deterministic = data.get("deterministic", False)
         input_text = process_input_text(input_text, use_mediawiki)
-        questions = llm_generator.generate_all_questions(input_text, mcq_count, bool_count, short_count)
+        questions = llm_generator.generate_all_questions(input_text, mcq_count, bool_count, short_count, deterministic)
         return jsonify({"output": questions})
     except Exception as e:
         app.logger.exception("Error in /get_problems_llm: %s", e)


### PR DESCRIPTION
### Summary

This PR introduces a deterministic mode for LLM-based question generation to enable reproducible outputs for identical inputs.

Currently, LLM-generated responses are non-deterministic due to stochastic sampling, which makes debugging, testing, and result comparison difficult. This change adds an optional mechanism to produce consistent outputs when required.

---

### What was implemented

- Added support for an optional `deterministic` flag in LLM-based API endpoints
- Updated `llm_generator.py` to conditionally control generation parameters
- When deterministic mode is enabled:
  - `temperature` is set to `0.0`
  - `top_p` is set to `1.0`
  - `seed` is derived from input text using: `hash(input_text) % (2**32)`
- Default behavior remains unchanged (`temperature = 0.7`)

---

### How this improves the system

- Enables reproducible outputs for identical inputs
- Simplifies debugging and issue tracking
- Improves reliability of testing workflows
- Provides controlled generation behavior without affecting existing functionality

---

### Scope

**In Scope**
- Deterministic generation for LLM-based endpoints
- Parameter control within existing generator methods

**Out of Scope**
- Retry logic
- Advanced configuration systems
- Architectural changes
- Frontend updates

---

### Screenshots/Recordings:

Not applicable (backend enhancement)

---

### Additional Notes:

This feature is optional and backward compatible. Deterministic mode prioritizes reproducibility over diversity and is intended for debugging, testing, and consistent evaluation scenarios.

---

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: ChatGPT (for guidance and review)

---

## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [ ] If applicable, I have made corresponding changes or additions to the documentation
- [ ] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional deterministic mode for question generation, enabling reproducible results for identical inputs across all question types (multiple choice, boolean, and short-answer).

* **Bug Fixes**
  * Enhanced input validation for question generation endpoints to gracefully handle invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->